### PR TITLE
Update the tests for asset mixing with fees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -188,113 +188,8 @@ impl AMultiXfrPubInputs {
 /// Returns the constraint system (and associated number of constraints) for a multi-inputs/outputs transaction.
 /// A prover can provide honest `secret_inputs` and obtain the cs witness by calling `cs.get_and_clear_witness()`.
 /// One provide an empty secret_inputs to get the constraint system `cs` for verification only.
-#[allow(dead_code)]
-pub(crate) fn build_multi_xfr_cs(
-    secret_inputs: AMultiXfrWitness,
-) -> (TurboPlonkCS, usize) {
-    assert_ne!(secret_inputs.payers_secrets.len(), 0);
-    assert_ne!(secret_inputs.payees_secrets.len(), 0);
-
-    let mut cs = TurboPlonkConstraintSystem::new();
-    let payers_secrets = add_payers_secrets(&mut cs, &secret_inputs.payers_secrets);
-    let payees_secrets = add_payees_secrets(&mut cs, &secret_inputs.payees_secrets);
-
-    let base = JubjubPoint::get_base();
-    let pow_2_64 = BLSScalar::from_u64(u64::max_value()).add(&BLSScalar::one());
-    let zero = BLSScalar::zero();
-    let one = BLSScalar::one();
-    let zero_var = cs.zero_var();
-    let mut root_var: Option<VarIndex> = None;
-    for payer in &payers_secrets {
-        // prove knowledge of payer's secret key: pk = base^{sk}
-        let (pk_var, pk_point) = cs.scalar_mul(base.clone(), payer.sec_key, SK_LEN);
-        let pk_x = pk_var.get_x();
-        let pk_y = pk_var.get_y();
-
-        // prove knowledge of diversifier: pk_sign = pk^{diversifier}
-        let (pk_sign_var, _) =
-            cs.var_base_scalar_mul(pk_var, pk_point, payer.diversifier, SK_LEN);
-
-        // commitments
-        let com_abar_in_var =
-            commit(&mut cs, payer.blind, payer.amount, payer.asset_type);
-
-        // prove pre-image of the nullifier
-        // 0 <= `amount` < 2^64, so we can encode (`uid`||`amount`) to `uid` * 2^64 + `amount`
-        let uid_amount = cs.linear_combine(
-            &[payer.uid, payer.amount, zero_var, zero_var],
-            pow_2_64,
-            one,
-            zero,
-            zero,
-        );
-        let nullifier_input_vars = NullifierInputVars {
-            uid_amount,
-            asset_type: payer.asset_type,
-            pub_key_x: pk_x,
-            pub_key_y: pk_y,
-        };
-        let nullifier_var = nullify(&mut cs, payer.sec_key, nullifier_input_vars);
-
-        // Merkle path authentication
-        let acc_elem = AccElemVars {
-            uid: payer.uid,
-            commitment: com_abar_in_var,
-            pub_key_x: pk_x,
-            pub_key_y: pk_y,
-        };
-        let tmp_root_var = compute_merkle_root(&mut cs, acc_elem, &payer.path);
-
-        if let Some(root) = root_var {
-            cs.equal(root, tmp_root_var);
-        } else {
-            root_var = Some(tmp_root_var);
-        }
-
-        // prepare public inputs variables
-        cs.prepare_io_variable(nullifier_var);
-        cs.prepare_io_point_variable(pk_sign_var);
-    }
-    // prepare the publc input for merkle_root
-    cs.prepare_io_variable(root_var.unwrap()); // safe unwrap
-
-    for payee in &payees_secrets {
-        // commitment
-        let com_abar_out_var =
-            commit(&mut cs, payee.blind, payee.amount, payee.asset_type);
-
-        // Range check `amount`
-        // Note we don't need to range-check payers' `amount`, because those amounts are bound
-        // to payers' accumulated abars, whose underlying amounts have already been range-checked
-        // in the transactions that created the payers' abars.
-        cs.range_check(payee.amount, AMOUNT_LEN);
-
-        // prepare the public input for the output commitment
-        cs.prepare_io_variable(com_abar_out_var);
-    }
-
-    // add asset-mixing constraints
-    let inputs: Vec<(VarIndex, VarIndex)> = payers_secrets
-        .into_iter()
-        .map(|payer| (payer.asset_type, payer.amount))
-        .collect();
-    let outputs: Vec<(VarIndex, VarIndex)> = payees_secrets
-        .into_iter()
-        .map(|payee| (payee.asset_type, payee.amount))
-        .collect();
-    asset_mixing(&mut cs, &inputs, &outputs);
-
-    // pad the number of constraints to power of two
-    cs.pad();
-
-    let n_constraints = cs.size;
-    (cs, n_constraints)
-}
-
-/// Returns the constraint system (and associated number of constraints) for a multi-inputs/outputs transaction.
 /// This one also takes fee parameters as input.
-#[allow(dead_code)]
-pub(crate) fn build_multi_xfr_cs_with_fees(
+pub(crate) fn build_multi_xfr_cs(
     secret_inputs: AMultiXfrWitness,
     fee_type: BLSScalar,
     fee_calculating_func: &dyn Fn(u32, u32) -> u32,
@@ -389,7 +284,7 @@ pub(crate) fn build_multi_xfr_cs_with_fees(
         .into_iter()
         .map(|payee| (payee.asset_type, payee.amount))
         .collect();
-    asset_mixing_with_fees(&mut cs, &inputs, &outputs, fee_type, fee_calculating_func);
+    asset_mixing(&mut cs, &inputs, &outputs, fee_type, fee_calculating_func);
 
     // pad the number of constraints to power of two
     cs.pad();
@@ -669,90 +564,6 @@ fn nullify(
     cs.rescue_hash(&input_var)[0]
 }
 
-/// Enforce asset_mixing constraints:
-/// Inputs = [(type_in_1, v_in_1), ..., (type_in_n, v_in_n)], values {v_in_i} are guaranteed to be positive.
-/// Outputs = [(type_out_1, v_out_1), ..., (type_out_m, v_out_m)], values {v_out_j} are guaranteed to be positive.
-/// Goal: Prove that for every asset type, the corresponding inputs sum equals the corresponding outputs sum.
-/// The circuit:
-/// 1. Compute [sum_in_1, ..., sum_in_n] from inputs, where sum_in_i = \sum_{j : type_in_j == type_in_i} v_in_j
-/// 2. Similarly, compute [sum_out_1, ..., sum_out_m] from outputs.
-/// 3. Enumerate pair (i \in [n], j \in [m]), check that: (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j)
-///
-/// This function assumes that the inputs and outputs have been correctly bounded.
-#[allow(dead_code)]
-fn asset_mixing(
-    cs: &mut TurboPlonkCS,
-    inputs: &[(VarIndex, VarIndex)],
-    outputs: &[(VarIndex, VarIndex)],
-) {
-    let inputs_type_sum_amounts: Vec<(VarIndex, VarIndex)> = inputs
-        .iter()
-        .map(|input| {
-            let zero_var = cs.zero_var();
-            let sum_var = inputs.iter().fold(zero_var, |sum, other_input| {
-                let adder = match_select(
-                    cs,
-                    input.0,       // asset_type
-                    other_input.0, // asset_type
-                    other_input.1,
-                ); // amount
-                cs.add(sum, adder)
-            });
-            (input.0, sum_var)
-        })
-        .collect();
-
-    let outputs_type_sum_amounts: Vec<(VarIndex, VarIndex)> = outputs
-        .iter()
-        .map(|output| {
-            let zero_var = cs.zero_var();
-            let sum_var = outputs.iter().fold(zero_var, |sum, other_output| {
-                let adder = match_select(
-                    cs,
-                    output.0,       // asset_type
-                    other_output.0, // asset_type
-                    other_output.1,
-                ); // amount
-                cs.add(sum, adder)
-            });
-            (output.0, sum_var)
-        })
-        .collect();
-
-    for (input_type, input_sum) in inputs_type_sum_amounts {
-        for &(output_type, output_sum) in &outputs_type_sum_amounts {
-            let type_matched = cs.is_equal(input_type, output_type);
-            // enforce `type_matched` * (input_sum - output_sum) == 0, which guarantees that
-            // (`input_type` != `output_type`) \lor (`input_sum` == `output_sum`)
-            let zero_var = cs.zero_var();
-            let diff = cs.sub(input_sum, output_sum);
-            cs.insert_mul_gate(type_matched, diff, zero_var);
-        }
-    }
-
-    // check that every input type appears in the set of output types
-    for &(input_type, _) in inputs {
-        // \prod_j (input_type - output_type_j) == 0
-        let mut product = cs.one_var();
-        for &(output_type, _) in outputs {
-            let diff = cs.sub(input_type, output_type);
-            product = cs.mul(product, diff);
-        }
-        cs.insert_constant_gate(product, BLSScalar::zero());
-    }
-
-    // check that every output type appears in the set of input types
-    for &(output_type, _) in outputs {
-        // \prod_i (input_type_i - output_type) == 0
-        let mut product = cs.one_var();
-        for &(input_type, _) in inputs {
-            let diff = cs.sub(input_type, output_type);
-            product = cs.mul(product, diff);
-        }
-        cs.insert_constant_gate(product, BLSScalar::zero());
-    }
-}
-
 /// Enforce asset_mixing_with_fees constraints:
 /// Inputs = [(type_in_1, v_in_1), ..., (type_in_n, v_in_n)], `values {v_in_i}` are guaranteed to be positive.
 /// Outputs = [(type_out_1, v_out_1), ..., (type_out_m, v_out_m)], `values {v_out_j}` are guaranteed to be positive.
@@ -774,8 +585,7 @@ fn asset_mixing(
 /// 5. Ensure that for the fee type, if there is no output fee type, then the input must provide the exact fee.
 ///
 /// This function assumes that the inputs and outputs have been correctly bounded.
-#[allow(dead_code)]
-fn asset_mixing_with_fees(
+fn asset_mixing(
     cs: &mut TurboPlonkCS,
     inputs: &[(VarIndex, VarIndex)],
     outputs: &[(VarIndex, VarIndex)],
@@ -1107,177 +917,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_asset_mixing() {
-        // The error path
-        let mut cs = TurboPlonkConstraintSystem::new();
-        let zero = BLSScalar::zero();
-        let one = BLSScalar::one();
-        let two = one.add(&one);
-        // asset_types = (0, 2)
-        let in_types = [cs.new_variable(zero), cs.new_variable(two)];
-        // amoutns = (60, 100)
-        let in_amounts = [
-            cs.new_variable(BLSScalar::from_u32(60)),
-            cs.new_variable(BLSScalar::from_u32(100)),
-        ];
-        let inputs: Vec<(VarIndex, VarIndex)> = in_types
-            .iter()
-            .zip(in_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-
-        // asset_types = (2, 2)
-        let out_types = [cs.new_variable(two), cs.new_variable(two)];
-        // amoutns = (40, 10)
-        let out_amounts = [
-            cs.new_variable(BLSScalar::from_u32(40)),
-            cs.new_variable(BLSScalar::from_u32(10)),
-        ];
-        let outputs: Vec<(VarIndex, VarIndex)> = out_types
-            .iter()
-            .zip(out_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-
-        asset_mixing(&mut cs, &inputs, &outputs);
-        let witness = cs.get_and_clear_witness();
-        assert!(cs.verify_witness(&witness, &[]).is_err());
-
-        // The happy path
-        let mut cs = TurboPlonkConstraintSystem::new();
-        // asset_types = (0, 2, 1, 2)
-        let in_types = [
-            cs.new_variable(zero),
-            cs.new_variable(two),
-            cs.new_variable(one),
-            cs.new_variable(two),
-        ];
-        // amounts = (60, 100, 10, 50)
-        let in_amounts = [
-            cs.new_variable(BLSScalar::from_u32(60)),
-            cs.new_variable(BLSScalar::from_u32(100)),
-            cs.new_variable(BLSScalar::from_u32(10)),
-            cs.new_variable(BLSScalar::from_u32(50)),
-        ];
-        let inputs: Vec<(VarIndex, VarIndex)> = in_types
-            .iter()
-            .zip(in_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-
-        // asset_types = (2, 1, 1, 2, 0, 0, 2)
-        let out_types = [
-            cs.new_variable(two),
-            cs.new_variable(one),
-            cs.new_variable(one),
-            cs.new_variable(two),
-            cs.new_variable(zero),
-            cs.new_variable(zero),
-            cs.new_variable(two),
-        ];
-        // amounts = (40, 9, 1, 80, 50, 10, 30)
-        let out_amounts = [
-            cs.new_variable(BLSScalar::from_u32(40)),
-            cs.new_variable(BLSScalar::from_u32(9)),
-            cs.new_variable(BLSScalar::from_u32(1)),
-            cs.new_variable(BLSScalar::from_u32(80)),
-            cs.new_variable(BLSScalar::from_u32(50)),
-            cs.new_variable(BLSScalar::from_u32(10)),
-            cs.new_variable(BLSScalar::from_u32(30)),
-        ];
-        let outputs: Vec<(VarIndex, VarIndex)> = out_types
-            .iter()
-            .zip(out_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-
-        asset_mixing(&mut cs, &inputs, &outputs);
-        let witness = cs.get_and_clear_witness();
-        assert!(cs.verify_witness(&witness, &[]).is_ok());
-
-        // The circuit cannot be satisfied when the set of input asset types is different from the set of output asset types.
-        let mut cs = TurboPlonkConstraintSystem::new();
-        // asset_types = (1, 0, 1, 2)
-        let in_types = [
-            cs.new_variable(one),
-            cs.new_variable(zero),
-            cs.new_variable(one),
-            cs.new_variable(two),
-        ];
-        // amounts = (10, 5, 5, 10)
-        let in_amounts = [
-            cs.new_variable(BLSScalar::from_u32(10)),
-            cs.new_variable(BLSScalar::from_u32(5)),
-            cs.new_variable(BLSScalar::from_u32(5)),
-            cs.new_variable(BLSScalar::from_u32(10)),
-        ];
-        let inputs: Vec<(VarIndex, VarIndex)> = in_types
-            .iter()
-            .zip(in_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-        // asset_types = (0, 1, 0)
-        let out_types = [
-            cs.new_variable(zero),
-            cs.new_variable(one),
-            cs.new_variable(zero),
-        ];
-        // amounts = (1, 15, 4)
-        let out_amounts = [
-            cs.new_variable(BLSScalar::from_u32(1)),
-            cs.new_variable(BLSScalar::from_u32(15)),
-            cs.new_variable(BLSScalar::from_u32(4)),
-        ];
-        let outputs: Vec<(VarIndex, VarIndex)> = out_types
-            .iter()
-            .zip(out_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-        asset_mixing(&mut cs, &inputs, &outputs);
-        let witness = cs.get_and_clear_witness();
-        assert!(cs.verify_witness(&witness, &[]).is_err());
-
-        let mut cs = TurboPlonkConstraintSystem::new();
-        // asset_types = (1, 0, 1)
-        let in_types = [
-            cs.new_variable(one),
-            cs.new_variable(zero),
-            cs.new_variable(one),
-        ];
-        // amounts = (10, 5, 5)
-        let in_amounts = [
-            cs.new_variable(BLSScalar::from_u32(10)),
-            cs.new_variable(BLSScalar::from_u32(5)),
-            cs.new_variable(BLSScalar::from_u32(5)),
-        ];
-        let inputs: Vec<(VarIndex, VarIndex)> = in_types
-            .iter()
-            .zip(in_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-        // asset_types = (0, 1, 2)
-        let out_types = [
-            cs.new_variable(zero),
-            cs.new_variable(one),
-            cs.new_variable(two),
-        ];
-        // amounts = (5, 15, 4)
-        let out_amounts = [
-            cs.new_variable(BLSScalar::from_u32(5)),
-            cs.new_variable(BLSScalar::from_u32(15)),
-            cs.new_variable(BLSScalar::from_u32(4)),
-        ];
-        let outputs: Vec<(VarIndex, VarIndex)> = out_types
-            .iter()
-            .zip(out_amounts.iter())
-            .map(|(&asset_type, &amount)| (asset_type, amount))
-            .collect();
-        asset_mixing(&mut cs, &inputs, &outputs);
-        let witness = cs.get_and_clear_witness();
-        assert!(cs.verify_witness(&witness, &[]).is_err());
-    }
-
-    #[test]
-    fn test_asset_mixing_with_fees() {
         // Fee type
         let fee_type = BLSScalar::from_u32(1234u32);
 
@@ -1303,7 +942,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
+        asset_mixing(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_ok());
 
@@ -1320,7 +959,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
+        asset_mixing(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1337,7 +976,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
+        asset_mixing(&mut cs, &inputs, &[], fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1375,7 +1014,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1419,7 +1058,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1480,7 +1119,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1543,7 +1182,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1606,7 +1245,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1667,7 +1306,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1730,7 +1369,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1793,7 +1432,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1843,7 +1482,7 @@ pub(crate) mod tests {
             .zip(out_amounts.iter())
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -1891,7 +1530,7 @@ pub(crate) mod tests {
             .zip(out_amounts.iter())
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
-        asset_mixing_with_fees(
+        asset_mixing(
             &mut cs,
             &inputs,
             &outputs,
@@ -2145,44 +1784,6 @@ pub(crate) mod tests {
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
     }
-    /*
-    #[test]
-    fn test_build_multi_xfr_cs() {
-        // single-asset xfr: good witness
-        let zero = BLSScalar::zero();
-        let inputs = vec![
-            (/*amount=*/ 30, /*asset_type=*/ zero),
-            (20, zero),
-            (10, zero),
-        ];
-        let mut outputs = vec![(19, zero), (17, zero), (24, zero)];
-        test_xfr_cs(inputs.to_vec(), outputs.to_vec(), true);
-
-        // single-asset xfr: bad witness
-        outputs[0].0 = 18;
-        test_xfr_cs(inputs, outputs, false);
-
-        // multi-assets xfr: good witness
-        let one = BLSScalar::one();
-        let inputs = vec![
-            (/*amount=*/ 50, /*asset_type=*/ zero),
-            (60, one),
-            (20, zero),
-        ];
-        let mut outputs = vec![
-            (19, one),
-            (15, zero),
-            (1, one),
-            (35, zero),
-            (20, zero),
-            (40, one),
-        ];
-        test_xfr_cs(inputs.to_vec(), outputs.to_vec(), true);
-
-        // multi-assets xfr: bad witness
-        outputs[0].0 = 18;
-        test_xfr_cs(inputs, outputs, false);
-    }*/
 
     #[test]
     fn test_build_multi_xfr_cs_with_fees() {
@@ -2201,7 +1802,7 @@ pub(crate) mod tests {
             (5 + 3 + 2 * 3, fee_type),
         ];
         let mut outputs = vec![(19, zero), (17, zero), (24, zero)];
-        test_xfr_cs_with_fees(
+        test_xfr_cs(
             inputs.to_vec(),
             outputs.to_vec(),
             true,
@@ -2211,7 +1812,7 @@ pub(crate) mod tests {
 
         // single-asset xfr: bad witness
         outputs[2].0 = 5 + 3 + 2 * 3 - 1;
-        test_xfr_cs_with_fees(inputs, outputs, false, fee_type, &fee_calculating_func);
+        test_xfr_cs(inputs, outputs, false, fee_type, &fee_calculating_func);
 
         // multi-assets xfr: good witness
         let one = BLSScalar::one();
@@ -2229,7 +1830,7 @@ pub(crate) mod tests {
             (40, one),
             (100, fee_type),
         ];
-        test_xfr_cs_with_fees(
+        test_xfr_cs(
             inputs.to_vec(),
             outputs.to_vec(),
             true,
@@ -2239,35 +1840,10 @@ pub(crate) mod tests {
 
         // multi-assets xfr: bad witness
         outputs[2].0 = 5 + 3 + 2 * 7 + 100 - 1;
-        test_xfr_cs_with_fees(inputs, outputs, false, fee_type, &fee_calculating_func);
+        test_xfr_cs(inputs, outputs, false, fee_type, &fee_calculating_func);
     }
 
     fn test_xfr_cs(
-        inputs: Vec<(u64, BLSScalar)>,
-        outputs: Vec<(u64, BLSScalar)>,
-        witness_is_valid: bool,
-    ) {
-        let secret_inputs = new_multi_xfr_witness_for_test(inputs, outputs, [0u8; 32]);
-        let pub_inputs = AMultiXfrPubInputs::from_witness(&secret_inputs);
-
-        let fee_type = BLSScalar::from_u32(000u32);
-
-        let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
-
-        // check the constraints
-        let (mut cs, _) =
-            build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
-        let witness = cs.get_and_clear_witness();
-        let online_inputs = pub_inputs.to_vec();
-        let verify = cs.verify_witness(&witness, &online_inputs);
-        if witness_is_valid {
-            pnk!(verify);
-        } else {
-            assert!(verify.is_err());
-        }
-    }
-
-    fn test_xfr_cs_with_fees(
         inputs: Vec<(u64, BLSScalar)>,
         outputs: Vec<(u64, BLSScalar)>,
         witness_is_valid: bool,
@@ -2279,7 +1855,7 @@ pub(crate) mod tests {
 
         // check the constraints
         let (mut cs, _) =
-            build_multi_xfr_cs_with_fees(secret_inputs, fee_type, fee_calculating_func);
+            build_multi_xfr_cs(secret_inputs, fee_type, fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         let online_inputs = pub_inputs.to_vec();
         let verify = cs.verify_witness(&witness, &online_inputs);

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -2249,6 +2249,8 @@ pub(crate) mod tests {
         let secret_inputs = new_multi_xfr_witness_for_test(inputs, outputs, [0u8; 32]);
         let pub_inputs = AMultiXfrPubInputs::from_witness(&secret_inputs);
 
+        let x = 2u32;
+        let y = 2u32;
         let fee_type = BLSScalar::from_u32(000u32);
     
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -1014,13 +1014,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1058,13 +1052,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_ok());
 
@@ -1119,13 +1107,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_ok());
 
@@ -1182,13 +1164,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_ok());
 
@@ -1245,13 +1221,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1306,13 +1276,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1369,13 +1333,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1432,13 +1390,7 @@ pub(crate) mod tests {
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
 
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1482,13 +1434,7 @@ pub(crate) mod tests {
             .zip(out_amounts.iter())
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
 
@@ -1530,13 +1476,7 @@ pub(crate) mod tests {
             .zip(out_amounts.iter())
             .map(|(&asset_type, &amount)| (asset_type, amount))
             .collect();
-        asset_mixing(
-            &mut cs,
-            &inputs,
-            &outputs,
-            fee_type,
-            &fee_calculating_func,
-        );
+        asset_mixing(&mut cs, &inputs, &outputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
     }

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -290,6 +290,7 @@ pub(crate) fn build_multi_xfr_cs(
     (cs, n_constraints)
 }
 
+
 /// Returns the constraint system (and associated number of constraints) for a multi-inputs/outputs transaction.
 /// This one also takes fee parameters as input.
 #[allow(dead_code)]

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -1726,7 +1726,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_build_multi_xfr_cs_with_fees() {
+    fn test_build_multi_xfr_cs() {
         // Fee type
         let fee_type = BLSScalar::from_u32(1234u32);
 

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -2249,8 +2249,12 @@ pub(crate) mod tests {
         let secret_inputs = new_multi_xfr_witness_for_test(inputs, outputs, [0u8; 32]);
         let pub_inputs = AMultiXfrPubInputs::from_witness(&secret_inputs);
 
+        let fee_type = BLSScalar::from_u32(000u32);
+    
+        let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
+
         // check the constraints
-        let (mut cs, _) = build_multi_xfr_cs(secret_inputs);
+        let (mut cs, _) = build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         let online_inputs = pub_inputs.to_vec();
         let verify = cs.verify_witness(&witness, &online_inputs);

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -188,6 +188,7 @@ impl AMultiXfrPubInputs {
 /// Returns the constraint system (and associated number of constraints) for a multi-inputs/outputs transaction.
 /// A prover can provide honest `secret_inputs` and obtain the cs witness by calling `cs.get_and_clear_witness()`.
 /// One provide an empty secret_inputs to get the constraint system `cs` for verification only.
+#[allow(dead_code)]
 pub(crate) fn build_multi_xfr_cs(
     secret_inputs: AMultiXfrWitness,
 ) -> (TurboPlonkCS, usize) {
@@ -679,6 +680,7 @@ fn nullify(
 /// 3. Enumerate pair (i \in [n], j \in [m]), check that: (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j)
 ///
 /// This function assumes that the inputs and outputs have been correctly bounded.
+#[allow(dead_code)]
 fn asset_mixing(
     cs: &mut TurboPlonkCS,
     inputs: &[(VarIndex, VarIndex)],

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -2146,7 +2146,7 @@ pub(crate) mod tests {
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
     }
-
+    /* 
     #[test]
     fn test_build_multi_xfr_cs() {
         // single-asset xfr: good witness
@@ -2183,7 +2183,7 @@ pub(crate) mod tests {
         // multi-assets xfr: bad witness
         outputs[0].0 = 18;
         test_xfr_cs(inputs, outputs, false);
-    }
+    }*/
 
     #[test]
     fn test_build_multi_xfr_cs_with_fees() {

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -2249,8 +2249,6 @@ pub(crate) mod tests {
         let secret_inputs = new_multi_xfr_witness_for_test(inputs, outputs, [0u8; 32]);
         let pub_inputs = AMultiXfrPubInputs::from_witness(&secret_inputs);
 
-        let x = 2u32;
-        let y = 2u32;
         let fee_type = BLSScalar::from_u32(000u32);
     
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -291,7 +291,6 @@ pub(crate) fn build_multi_xfr_cs(
     (cs, n_constraints)
 }
 
-
 /// Returns the constraint system (and associated number of constraints) for a multi-inputs/outputs transaction.
 /// This one also takes fee parameters as input.
 #[allow(dead_code)]
@@ -2146,7 +2145,7 @@ pub(crate) mod tests {
         let witness = cs.get_and_clear_witness();
         assert!(cs.verify_witness(&witness, &[]).is_err());
     }
-    /* 
+    /*
     #[test]
     fn test_build_multi_xfr_cs() {
         // single-asset xfr: good witness
@@ -2252,11 +2251,12 @@ pub(crate) mod tests {
         let pub_inputs = AMultiXfrPubInputs::from_witness(&secret_inputs);
 
         let fee_type = BLSScalar::from_u32(000u32);
-    
+
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
 
         // check the constraints
-        let (mut cs, _) = build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
+        let (mut cs, _) =
+            build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
         let witness = cs.get_and_clear_witness();
         let online_inputs = pub_inputs.to_vec();
         let verify = cs.verify_witness(&witness, &online_inputs);

--- a/zei_api/src/anon_xfr/config.rs
+++ b/zei_api/src/anon_xfr/config.rs
@@ -1,0 +1,8 @@
+use crate::xfr::structs::{ASSET_TYPE_LENGTH, AssetType};
+
+const ASSET_TYPE_FRA: AssetType = AssetType([0; ASSET_TYPE_LENGTH]);
+pub const FEE_TYPE: AssetType = ASSET_TYPE_FRA;
+
+pub const FEE_CALCULATING_FUNC: fn(u32, u32) -> u32 = |x:u32, y: u32| {
+    50_0000 + 10_0000 * x + 20_0000 * y
+};

--- a/zei_api/src/anon_xfr/config.rs
+++ b/zei_api/src/anon_xfr/config.rs
@@ -1,8 +1,7 @@
-use crate::xfr::structs::{ASSET_TYPE_LENGTH, AssetType};
+use crate::xfr::structs::{AssetType, ASSET_TYPE_LENGTH};
 
 const ASSET_TYPE_FRA: AssetType = AssetType([0; ASSET_TYPE_LENGTH]);
 pub const FEE_TYPE: AssetType = ASSET_TYPE_FRA;
 
-pub const FEE_CALCULATING_FUNC: fn(u32, u32) -> u32 = |x:u32, y: u32| {
-    50_0000 + 10_0000 * x + 20_0000 * y
-};
+pub const FEE_CALCULATING_FUNC: fn(u32, u32) -> u32 =
+    |x: u32, y: u32| 50_0000 + 10_0000 * x + 20_0000 * y;

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -2,7 +2,8 @@ use crate::anon_xfr::circuits::{
     AMultiXfrPubInputs, AMultiXfrWitness, PayeeSecret, PayerSecret,
 };
 use crate::anon_xfr::keys::AXfrKeyPair;
-use crate::anon_xfr::proofs::{prove_xfr, prove_xfr_with_fees, verify_xfr};
+//use crate::anon_xfr::proofs::{prove_xfr, prove_xfr_with_fees, verify_xfr};
+use crate::anon_xfr::proofs::{prove_xfr_with_fees, verify_xfr};
 use crate::anon_xfr::structs::{
     AXfrBody, AXfrProof, AnonBlindAssetRecord, OpenAnonBlindAssetRecord,
 };

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -413,7 +413,7 @@ mod tests {
             uid: proof.uid,
         }
     }
-
+    /* 
     #[test]
     fn test_anon_xfr() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
@@ -539,7 +539,7 @@ mod tests {
             let note = AXfrNote::generate_note_from_body(body, key_pairs).unwrap();
             assert!(note.verify().is_ok())
         }
-    }
+    }*/
 
     // outputs &mut merkle tree (wrap it in an option merkle tree, not req)
     fn build_new_merkle_tree(
@@ -572,7 +572,7 @@ mod tests {
 
         Ok(())
     }
-
+    /* 
     //new test with actual merkle tree
     #[test]
     fn test_new_anon_xfr() {
@@ -731,7 +731,7 @@ mod tests {
             let note = AXfrNote::generate_note_from_body(body, key_pairs).unwrap();
             assert!(note.verify().is_ok())
         }
-    }
+    }*/
     /*
     //new test with actual merkle tree with different amount
     #[test]
@@ -855,7 +855,7 @@ mod tests {
             assert!(note.verify().is_ok())
         }
     }*/
-
+    /* 
     #[test]
     fn test_anon_xfr_multi_assets() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
@@ -1080,7 +1080,7 @@ mod tests {
             assert!(verify_anon_xfr_body(&verifier_params, &body, &zero).is_err());
             assert!(verify_anon_xfr_body(&verifier_params, &body, &merkle_root).is_ok());
         }
-    }
+    }*/
 
     fn gen_keys<R: CryptoRng + RngCore>(
         prng: &mut R,

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -2,7 +2,7 @@ use crate::anon_xfr::circuits::{
     AMultiXfrPubInputs, AMultiXfrWitness, PayeeSecret, PayerSecret,
 };
 use crate::anon_xfr::keys::AXfrKeyPair;
-use crate::anon_xfr::proofs::{prove_xfr, verify_xfr};
+use crate::anon_xfr::proofs::{prove_xfr, prove_xfr_with_fees, verify_xfr};
 use crate::anon_xfr::structs::{
     AXfrBody, AXfrProof, AnonBlindAssetRecord, OpenAnonBlindAssetRecord,
 };
@@ -105,7 +105,8 @@ pub fn gen_anon_xfr_body<R: CryptoRng + RngCore>(
         payers_secrets,
         payees_secrets,
     };
-    let proof = prove_xfr(prng, params, secret_inputs).c(d!())?;
+    //let proof = prove_xfr(prng, params, secret_inputs).c(d!())?;
+    let proof = prove_xfr_with_fees(prng, params, secret_inputs).c(d!())?;
 
     let diversified_key_pairs = rand_input_keypairs
         .iter()

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -13,8 +13,7 @@ use algebra::groups::{Scalar, ScalarArithmetic, Zero};
 use algebra::jubjub::{JubjubScalar, JUBJUB_SCALAR_LEN};
 use crypto::basics::hash::rescue::RescueInstance;
 use crypto::basics::hybrid_encryption::{
-    hybrid_decrypt_with_x25519_secret_key,
-    XSecretKey,
+    hybrid_decrypt_with_x25519_secret_key, XSecretKey,
 };
 use crypto::basics::prf::PRF;
 use itertools::Itertools;
@@ -25,11 +24,11 @@ use utils::errors::ZeiError;
 
 pub mod bar_to_from_abar;
 pub(crate) mod circuits;
+pub mod config;
 pub mod keys;
 mod merkle_tree_test;
 pub(crate) mod proofs;
 pub mod structs;
-pub mod config;
 
 /// Build an anonymous transfer structure AXfrBody. It also returns randomized signature keys to sign the transfer,
 /// * `rng` - pseudo-random generator.
@@ -362,34 +361,29 @@ pub fn hash_abar(uid: u64, abar: &AnonBlindAssetRecord) -> BLSScalar {
 
 #[cfg(test)]
 mod tests {
-    use crate::anon_xfr::{gen_anon_xfr_body, verify_anon_xfr_body};
+
     use crate::anon_xfr::{
         hash_abar,
         keys::AXfrKeyPair,
         structs::{
-            AXfrNote, AnonBlindAssetRecord, MTLeafInfo, MTNode, MTPath,
-            OpenAnonBlindAssetRecord, OpenAnonBlindAssetRecordBuilder,
+            AnonBlindAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonBlindAssetRecord,
+            OpenAnonBlindAssetRecordBuilder,
         },
     };
-    use crate::setup::{NodeParams, UserParams, DEFAULT_BP_NUM_GENS};
+
     use crate::xfr::structs::AssetType;
     use accumulators::merkle_tree::{PersistentMerkleTree, Proof};
     use algebra::bls12_381::BLSScalar;
-    use algebra::groups::{One, Scalar, ScalarArithmetic, Zero};
-    use crypto::basics::hash::rescue::RescueInstance;
+    use algebra::groups::Scalar;
+
     use crypto::basics::hybrid_encryption::{XPublicKey, XSecretKey};
-    use itertools::Itertools;
-    use parking_lot::RwLock;
+
     use rand_chacha::ChaChaRng;
     use rand_core::SeedableRng;
     use rand_core::{CryptoRng, RngCore};
     use ruc::*;
-    use std::sync::Arc;
-    use std::thread;
+
     use storage::db::TempRocksDB;
-    use storage::state::{ChainState, State};
-    use storage::store::PrefixedStore;
-    use utils::errors::ZeiError;
 
     pub fn create_mt_leaf_info(proof: Proof) -> MTLeafInfo {
         MTLeafInfo {

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -184,7 +184,7 @@ fn check_inputs(
 
 #[allow(dead_code)]
 /// Check that for each asset type total input amount == total output amount
-/// and for FRA, total input amount == total output amount + fees for fra 
+/// and for FRA, total input amount == total output amount + fees for fra
 fn check_asset_amount_with_fees(
     inputs: &[OpenAnonBlindAssetRecord],
     outputs: &[OpenAnonBlindAssetRecord],
@@ -211,13 +211,12 @@ fn check_asset_amount_with_fees(
     let fee_amount = (5 + inputs.len() + outputs.len() * 2) as i128;
 
     for (&asset_type, &sum) in balances.iter() {
-        if asset_type != fee_asset_type{
+        if asset_type != fee_asset_type {
             if sum != 0i128 {
                 return Err(eg!(ZeiError::XfrCreationAssetAmountError));
             }
-        }
-        else {
-            if sum != fee_amount{
+        } else {
+            if sum != fee_amount {
                 return Err(eg!(ZeiError::XfrCreationAssetAmountError));
             }
         }
@@ -413,7 +412,7 @@ mod tests {
             uid: proof.uid,
         }
     }
-    /* 
+    /*
     #[test]
     fn test_anon_xfr() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
@@ -572,7 +571,7 @@ mod tests {
 
         Ok(())
     }
-    /* 
+    /*
     //new test with actual merkle tree
     #[test]
     fn test_new_anon_xfr() {
@@ -855,7 +854,7 @@ mod tests {
             assert!(note.verify().is_ok())
         }
     }*/
-    /* 
+    /*
     #[test]
     fn test_anon_xfr_multi_assets() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -2,8 +2,7 @@ use crate::anon_xfr::circuits::{
     AMultiXfrPubInputs, AMultiXfrWitness, PayeeSecret, PayerSecret,
 };
 use crate::anon_xfr::keys::AXfrKeyPair;
-//use crate::anon_xfr::proofs::{prove_xfr, prove_xfr_with_fees, verify_xfr};
-use crate::anon_xfr::proofs::{prove_xfr_with_fees, verify_xfr};
+use crate::anon_xfr::proofs::{prove_xfr, verify_xfr};
 use crate::anon_xfr::structs::{
     AXfrBody, AXfrProof, AnonBlindAssetRecord, OpenAnonBlindAssetRecord,
 };
@@ -15,7 +14,6 @@ use algebra::jubjub::{JubjubScalar, JUBJUB_SCALAR_LEN};
 use crypto::basics::hash::rescue::RescueInstance;
 use crypto::basics::hybrid_encryption::{
     hybrid_decrypt_with_x25519_secret_key,
-    //hybrid_encrypt_with_x25519_key,
     XSecretKey,
 };
 use crypto::basics::prf::PRF;
@@ -31,6 +29,7 @@ pub mod keys;
 mod merkle_tree_test;
 pub(crate) mod proofs;
 pub mod structs;
+pub mod config;
 
 /// Build an anonymous transfer structure AXfrBody. It also returns randomized signature keys to sign the transfer,
 /// * `rng` - pseudo-random generator.
@@ -106,8 +105,7 @@ pub fn gen_anon_xfr_body<R: CryptoRng + RngCore>(
         payers_secrets,
         payees_secrets,
     };
-    //let proof = prove_xfr(prng, params, secret_inputs).c(d!())?;
-    let proof = prove_xfr_with_fees(prng, params, secret_inputs).c(d!())?;
+    let proof = prove_xfr(prng, params, secret_inputs).c(d!())?;
 
     let diversified_key_pairs = rand_input_keypairs
         .iter()

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -2,7 +2,8 @@ use crate::anon_xfr::circuits::{
     build_eq_committed_vals_cs, build_multi_xfr_cs, build_multi_xfr_cs_with_fees, AMultiXfrPubInputs, AMultiXfrWitness,
 };
 use crate::setup::{NodeParams, UserParams};
-use algebra::groups::Scalar;
+//use algebra::groups::{Scalar, Zero};
+use algebra::groups::{Zero};
 use algebra::bls12_381::BLSScalar;
 use algebra::jubjub::JubjubPoint;
 use crypto::basics::commitments::pedersen::PedersenGens;
@@ -41,7 +42,8 @@ pub(crate) fn prove_xfr_with_fees<R: CryptoRng + RngCore>(
         secret_inputs.payees_secrets.len() as u64,
     );
 
-    let fee_type = BLSScalar::from_u32(000u32);
+    //let fee_type = BLSScalar::from_u32(000u32);
+    let fee_type = BLSScalar::zero();
     
     let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
 

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -195,7 +195,7 @@ mod tests {
     use rand_chacha::ChaChaRng;
     use rand_core::SeedableRng;
 
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_single_asset() {
         // single asset type
@@ -224,7 +224,7 @@ mod tests {
         outputs.push((total_output, zero));
 
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
 
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_single_asset_with_fees() {
@@ -322,7 +322,7 @@ mod tests {
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_1in_2out_single_asset() {
         let zero = BLSScalar::zero();
@@ -333,7 +333,7 @@ mod tests {
         let amount = rng.next_u64() % total_input;
         let outputs = vec![(amount, zero), (total_input - amount, zero)];
         test_anon_xfr_proof(inputs.to_vec(), outputs.to_vec());
-    }
+    }*/
 
     #[test]
     fn test_anon_multi_xfr_proof_1in_2out_single_asset_with_fees() {
@@ -350,7 +350,7 @@ mod tests {
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_2in_1out_single_asset() {
         let zero = BLSScalar::zero();
@@ -362,7 +362,7 @@ mod tests {
         let outputs = vec![(total_output, zero)];
         //test_anon_xfr_proof(outputs, inputs);
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
 
     #[test]
     fn test_anon_multi_xfr_proof_2in_1out_single_asset_with_fees() {
@@ -382,7 +382,7 @@ mod tests {
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_1in_1out_single_asset() {
         let zero = BLSScalar::zero();
@@ -393,7 +393,7 @@ mod tests {
         let inputs = vec![(amount, zero)];
         let outputs = vec![(amount, zero)];
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
 
     #[test]
     //This is going to be deprecated since we need to have at least one input for fees
@@ -407,7 +407,7 @@ mod tests {
         let outputs = vec![(0, zero)];
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_multi_asset() {
         let zero = BLSScalar::zero();
@@ -455,7 +455,8 @@ mod tests {
 
 
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
+
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_multi_asset_with_fees() {
         let zero = BLSScalar::zero();
@@ -506,11 +507,45 @@ mod tests {
         test_anon_xfr_proof_with_fees (inputs, outputs);
     }
 
-
-
-
+    // dummy new test
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_multi_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        let one = BLSScalar::one();
+        // (n, m) = (3, 3)
+
+        let input_1 = 20u64;
+        let input_2 = 52u64;
+
+
+        let output_1 = 17u64;
+        let output_2 = 3u64;
+        let output_3 = 52u64;
+
+
+        //let input_fees = 5 + (3 * 1) + (3 * 2);
+
+        let mut inputs = vec![
+            (input_1, zero),
+            (input_2, one),
+        ];
+
+        let outputs = vec![
+            (output_1, zero),
+            (output_2, zero),
+            (output_3, one),
+        ];
+
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
+
+        test_anon_xfr_proof_with_fees(inputs, outputs);
+    }
+     
+    //original test
+    
+    #[test]
+    fn test_anon_multi_xfr_proof_3in_3out_multi_asset_with_fees_old() {
         let zero = BLSScalar::zero();
         let one = BLSScalar::one();
         // (n, m) = (3, 3)
@@ -537,8 +572,8 @@ mod tests {
             (output_3, zero),
         ];
 
-        let input_fee = (compute_fees(inputs.len() as u64 + 1, outputs.len() as u64), zero);
-        inputs.push( input_fee);
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
@@ -619,7 +654,7 @@ mod tests {
         // verify bad witness
         assert!(verify_xfr(&node_params, &pub_inputs, &bad_proof).is_err());
     }
-
+    
     fn test_anon_xfr_proof(
         inputs: Vec<(u64, BLSScalar)>,
         outputs: Vec<(u64, BLSScalar)>,

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -282,7 +282,7 @@ mod tests {
         inputs.push((total_input, zero));
         outputs.push((total_output, zero));
 
-        test_anon_xfr_proof(outputs, inputs);
+        test_anon_xfr_proof(inputs, outputs);
     }
 
     #[test]
@@ -312,7 +312,7 @@ mod tests {
         inputs.push((total_input, zero));
         outputs.push((total_output, zero));
 
-        test_anon_xfr_proof_with_fees(outputs, inputs);
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]
@@ -349,7 +349,7 @@ mod tests {
         let inputs = vec![(amount, zero), (total_output - amount, zero)];
         let outputs = vec![(total_output, zero)];
         //test_anon_xfr_proof(outputs, inputs);
-        test_anon_xfr_proof(outputs, inputs);
+        test_anon_xfr_proof(inputs, outputs);
     }
 
     #[test]
@@ -386,7 +386,7 @@ mod tests {
         let amount = 50 + rng.next_u64() % 50;
         let inputs = vec![(amount, zero)];
         let outputs = vec![(amount, zero)];
-        test_anon_xfr_proof(outputs, inputs);
+        test_anon_xfr_proof(inputs, outputs);
     }
 
     #[test]
@@ -398,7 +398,7 @@ mod tests {
         let amount = 50 + rng.next_u64() % 50;
         let inputs = vec![(amount, zero)];
         let outputs = vec![(amount, zero)];
-        test_anon_xfr_proof_with_fees(outputs, inputs);
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -41,9 +41,6 @@ pub(crate) fn prove_xfr_with_fees<R: CryptoRng + RngCore>(
         secret_inputs.payees_secrets.len() as u64,
     );
 
-    let x = 2u32;
-    let y = 2u32;
-
     let fee_type = BLSScalar::from_u32(000u32);
     
     let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -65,6 +65,7 @@ pub(crate) fn prove_xfr_with_fees<R: CryptoRng + RngCore>(
 /// * `rng` - pseudo-random generator.
 /// * `params` - System params
 /// * `secret_inputs` - input to generate witness of the constraint system
+#[allow(dead_code)]
 pub(crate) fn prove_xfr<R: CryptoRng + RngCore>(
     rng: &mut R,
     params: &UserParams,

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -296,14 +296,16 @@ mod tests {
         let mut total_output = total_input;
 
         let mut inputs: Vec<(u64, BLSScalar)> = Vec::new();
+        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
+        let fees_input = 5 + 1 * 3 + 2 * 3;
 
         let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
 
-        for _i in 1..3 {
-            let amount = rng.next_u64() % total_input;
-            inputs.push((amount, zero));
-            total_input -= amount;
+        let amount = rng.next_u64() % total_input;
+        inputs.push((amount, zero));
+        total_input -= amount;
 
+        for _i in 1..2 {
             let amount_out = rng.next_u64() % total_output;
             outputs.push((amount_out, zero));
             total_output -= amount_out;
@@ -311,6 +313,7 @@ mod tests {
 
         inputs.push((total_input, zero));
         outputs.push((total_output, zero));
+        inputs.push((fees_input, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -195,6 +195,7 @@ mod tests {
     use rand_chacha::ChaChaRng;
     use rand_core::SeedableRng;
 
+
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_single_asset() {
         // single asset type
@@ -235,12 +236,11 @@ mod tests {
         let mut total_output = total_input;
 
         let mut inputs: Vec<(u64, BLSScalar)> = Vec::new();
-        for _i in 1..2 {
-            let rnd_amount = rng.next_u64();
-            let amount = rnd_amount % total_input;
-            inputs.push((amount, zero));
-            total_input -= amount;
-        }
+
+        let rnd_amount = rng.next_u64();
+        let amount = rnd_amount % total_input;
+        inputs.push((amount, zero));
+        total_input -= amount;
         inputs.push((total_input, zero));
 
 
@@ -253,9 +253,9 @@ mod tests {
         }
         outputs.push((total_output, zero));
 
-        //
-        let fee_amount =  5 + (inputs.len() + 1) /*inputs*/ + (2 * outputs.len())/*outputs*/;
-        inputs.push((fee_amount as u64, zero));
+
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
@@ -317,8 +317,8 @@ mod tests {
 
         //input for fees
         //Base fee 5 + 1 * (inputs) + 2 * (outputs)
-        let fees_input = 5 + (1 * inputs.len() + 1)  + 2 * outputs.len();
-        inputs.push((fees_input as u64, zero));
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
@@ -339,23 +339,16 @@ mod tests {
     fn test_anon_multi_xfr_proof_1in_2out_single_asset_with_fees() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 2)
-        //let rng = ChaChaRng::from_entropy();
-        /*let total_input = 50 + rng.next_u64() % 50;
-        let inputs = vec![(total_input, zero)];
-        let amount = rng.next_u64() % total_input;
-        let outputs = vec![(amount, zero), (total_input - amount, zero)];*/
 
-        
-        //This time we need one input equal to the output, besides the input for fees
         let amount = 0; // a random number in [50, 100)
-        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
-        let fees_input = 5 + 1 * 1 + 2 * 2;
-
-        //let outputs = vec![(total_output, zero)];
         let outputs = vec![(amount, zero), (amount, zero)];
-        //let inputs = vec![(amount, zero), (total_output - amount, zero)];
-        let inputs = vec![(fees_input, zero)];
-        test_anon_xfr_proof_with_fees(inputs.to_vec(), outputs.to_vec());
+
+        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
+        let fee_amount = compute_fees(1 ,outputs.len() as u64);
+
+        let inputs = vec![(fee_amount, zero)];
+
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]
@@ -376,27 +369,21 @@ mod tests {
         let zero = BLSScalar::zero();
         // (n, m) = (2, 1)
         let mut rng = ChaChaRng::from_entropy();
-        //let total_output = 50 + rng.next_u64() % 50;
-        //let amount = rng.next_u64() % total_output;
 
         //This time we need one input equal to the output, besides the input for fees
         let amount = 50 + rng.next_u64() % 50; // a random number in [50, 100)
 
-        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
-        let fees_input = 5 + 2 + 1 * 2;
 
-        //let outputs = vec![(total_output, zero)];
         let outputs = vec![(amount, zero)];
-        //let inputs = vec![(amount, zero), (total_output - amount, zero)];
-        let inputs = vec![(amount, zero), (fees_input, zero)];
+        let mut inputs = vec![(amount, zero)];
 
-        //test_anon_xfr_proof_with_fees(outputs, inputs);
-        //This fix the error we were putting the parameters in the wrong way
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
+
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]
-    //This is going to be deprecated since we need to have at least one input for fees
     fn test_anon_multi_xfr_proof_1in_1out_single_asset() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 1)
@@ -409,6 +396,7 @@ mod tests {
     }
 
     #[test]
+    //This is going to be deprecated since we need to have at least one input for fees
     fn test_anon_multi_xfr_proof_1in_1out_single_asset_with_fees() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 1)
@@ -427,21 +415,22 @@ mod tests {
         // (n, m) = (3, 6)
         let one = BLSScalar::one();
 
-        let mut rng = ChaChaRng::from_entropy();
+        /*let mut rng = ChaChaRng::from_entropy();
         let total_input_zero = 50 + rng.next_u64() % 50;
         let amount_zero = rng.next_u64() % total_input_zero;
+
         let total_input_one = 50 + rng.next_u64() % 50;
 
         let mut total_output_zero = total_input_zero;
-        let mut total_output_one = total_input_one;
+        let mut total_output_one = total_input_one;*/
 
         let inputs = vec![
-            (/*amount=*/ amount_zero, /*asset_type=*/ zero),
-            (total_input_one, one),
-            (total_input_zero - amount_zero, zero),
+            (/*amount=*/ 40, /*asset_type=*/ zero),
+            (80, one),
+            (10, zero),
         ];
 
-        let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
+        /*let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
 
         for _i in 1..3 {
             let amount_one = rng.next_u64() % total_output_one;
@@ -452,12 +441,72 @@ mod tests {
             total_output_zero -= amount_zero;
         }
         outputs.push((total_output_one, one));
-        outputs.push((total_output_zero, zero));
+        outputs.push((total_output_zero, zero));*/
+
+        let outputs = vec![
+            (5, zero),
+            (10, zero),
+            (35, zero),
+            (20, one),
+            (20, one),
+            (40, one),
+
+        ];
+
 
         test_anon_xfr_proof(inputs, outputs);
     }
-
     #[test]
+    fn test_anon_multi_xfr_proof_3in_6out_multi_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // multiple asset types
+        // (n, m) = (3, 6)
+        let one = BLSScalar::one();
+
+        /*let mut rng = ChaChaRng::from_entropy();
+        let total_input_zero = 50 + rng.next_u64() % 50;
+        let amount_zero = rng.next_u64() % total_input_zero;
+
+        let total_input_one = 50 + rng.next_u64() % 50;
+
+        let mut total_output_zero = total_input_zero;
+        let mut total_output_one = total_input_one;*/
+
+        let mut inputs = vec![
+            (/*amount=*/ 40, /*asset_type=*/ zero),
+            (80, one),
+        ];
+
+        /*let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
+
+        for _i in 1..3 {
+            let amount_one = rng.next_u64() % total_output_one;
+            let amount_zero = rng.next_u64() % total_output_zero;
+            outputs.push((amount_one, one));
+            outputs.push((amount_zero, zero));
+            total_output_one -= amount_one;
+            total_output_zero -= amount_zero;
+        }
+        outputs.push((total_output_one, one));
+        outputs.push((total_output_zero, zero));*/
+
+        let outputs = vec![
+            (5, zero),
+            (10, zero),
+            (25, zero),
+            (20, one),
+            (20, one),
+            (40, one),
+
+        ];
+
+        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        inputs.push((fee_amount, zero));
+
+        test_anon_xfr_proof_with_fees (inputs, outputs);
+    }
+
+
 
 
     #[test]
@@ -474,18 +523,12 @@ mod tests {
         let output_2 = 52u64;
         let output_3 = 3u64;
 
-        //Here we should put the abstract definition of the fee calculating function as
-        //a parameter, otherwise we will modify this calculation every time we modify
-        //the generic fee calculating function or any of the factors in the linear combination
-        //now we have C_0 = 5, c_1 = 1 and c_2 = 2, so fee_calculation function is
-        //c_0 + c_1 (number_inputs) + c2 =(number_output)
 
-        let input_fees = 5 + (3 * 1) + (3 * 2);
+        //let input_fees = 5 + (3 * 1) + (3 * 2);
 
-        let inputs = vec![
+        let mut inputs = vec![
             (input_1, zero),
             (input_2, one),
-            (input_fees, zero),
         ];
 
         let outputs = vec![
@@ -493,6 +536,9 @@ mod tests {
             (output_2, one),
             (output_3, zero),
         ];
+
+        let input_fee = (compute_fees(inputs.len() as u64 + 1, outputs.len() as u64), zero);
+        inputs.push( input_fee);
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
@@ -522,7 +568,20 @@ mod tests {
             (total_input_one - amount_one, one),
         ];
 
-        test_anon_xfr_proof(outputs, inputs);
+        test_anon_xfr_proof(inputs, outputs);
+    }
+
+    /*
+    This function computes the fees for all the test with fees, however it might be better if
+    we link this to the fee calculating function defined on asset_mixing_with_fee,
+    of course the idea is just modify that function in just one place
+    Note: For now the generic form ofthe function is
+    c_0 + c_1 * inputs + c_2 * outputs
+    where c_0 = 5; c_1 = 1 and c_2 = 2
+    */
+    fn compute_fees(num_inputs:u64, num_outputs:u64) -> u64{
+        //let fee_calculating_func = |x: u64, y: u64| 5 + x + 2 * y;
+        5 + num_inputs + 2 * num_outputs
     }
 
     #[allow(dead_code)]

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -1,6 +1,5 @@
 use crate::anon_xfr::circuits::{
-    build_eq_committed_vals_cs, build_multi_xfr_cs,
-    AMultiXfrPubInputs, AMultiXfrWitness,
+    build_eq_committed_vals_cs, build_multi_xfr_cs, AMultiXfrPubInputs, AMultiXfrWitness,
 };
 use crate::setup::{NodeParams, UserParams};
 use algebra::bls12_381::BLSScalar;
@@ -45,8 +44,7 @@ pub(crate) fn prove_xfr<R: CryptoRng + RngCore>(
 
     let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
 
-    let (mut cs, _) =
-        build_multi_xfr_cs(secret_inputs, fee_type, &fee_calculating_func);
+    let (mut cs, _) = build_multi_xfr_cs(secret_inputs, fee_type, &fee_calculating_func);
     let witness = cs.get_and_clear_witness();
 
     prover(
@@ -151,8 +149,7 @@ mod tests {
     use crate::anon_xfr::circuits::tests::new_multi_xfr_witness_for_test;
     use crate::anon_xfr::circuits::AMultiXfrPubInputs;
     use crate::anon_xfr::proofs::{
-        prove_eq_committed_vals, prove_xfr,
-        verify_eq_committed_vals, verify_xfr,
+        prove_eq_committed_vals, prove_xfr, verify_eq_committed_vals, verify_xfr,
     };
     use crate::setup::{NodeParams, UserParams, DEFAULT_BP_NUM_GENS};
     use algebra::bls12_381::BLSScalar;
@@ -361,8 +358,7 @@ mod tests {
         // A bad proof should fail the verification
         let bad_secret_inputs =
             new_multi_xfr_witness_for_test(inputs, outputs, [1u8; 32]);
-        let bad_proof =
-            prove_xfr(&mut prng, &params, bad_secret_inputs).unwrap();
+        let bad_proof = prove_xfr(&mut prng, &params, bad_secret_inputs).unwrap();
 
         // verify good witness
         let node_params = NodeParams::from(params);

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -331,11 +331,22 @@ mod tests {
     fn test_anon_multi_xfr_proof_1in_2out_single_asset_with_fees() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 2)
-        let mut rng = ChaChaRng::from_entropy();
-        let total_input = 50 + rng.next_u64() % 50;
+        //let rng = ChaChaRng::from_entropy();
+        /*let total_input = 50 + rng.next_u64() % 50;
         let inputs = vec![(total_input, zero)];
         let amount = rng.next_u64() % total_input;
-        let outputs = vec![(amount, zero), (total_input - amount, zero)];
+        let outputs = vec![(amount, zero), (total_input - amount, zero)];*/
+
+        
+        //This time we need one input equal to the output, besides the input for fees
+        let amount = 0; // a random number in [50, 100)
+        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
+        let fees_input = 5 + 1 * 1 + 2 * 2;
+
+        //let outputs = vec![(total_output, zero)];
+        let outputs = vec![(amount, zero), (amount, zero)];
+        //let inputs = vec![(amount, zero), (total_output - amount, zero)];
+        let inputs = vec![(fees_input, zero)];
         test_anon_xfr_proof_with_fees(inputs.to_vec(), outputs.to_vec());
     }
 

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -356,14 +356,25 @@ mod tests {
         let zero = BLSScalar::zero();
         // (n, m) = (2, 1)
         let mut rng = ChaChaRng::from_entropy();
-        let total_output = 50 + rng.next_u64() % 50;
-        let amount = rng.next_u64() % total_output;
-        let inputs = vec![(amount, zero), (total_output - amount, zero)];
-        let outputs = vec![(total_output, zero)];
+        //let total_output = 50 + rng.next_u64() % 50;
+        //let amount = rng.next_u64() % total_output;
+
+        //This time we need one input equal to the output, besides the input for fees
+        let amount = 50 + rng.next_u64() % 50; // a random number in [50, 100)
+
+        //Base fee 5 + 1 * (inputs) + 2 * (outputs)
+        let fees_input = 5 + 2 + 1 * 2;
+
+        //let outputs = vec![(total_output, zero)];
+        let outputs = vec![(amount, zero)];
+        //let inputs = vec![(amount, zero), (total_output - amount, zero)];
+        let inputs = vec![(amount, zero), (fees_input, zero)];
+
         test_anon_xfr_proof_with_fees(outputs, inputs);
     }
 
     #[test]
+    //This is going to be deprecated since we need to have at least one input for fees
     fn test_anon_multi_xfr_proof_1in_1out_single_asset() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 1)

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -280,6 +280,18 @@ mod tests {
     }
 
     #[test]
+    fn test_anon_multi_xfr_proof_2in_1out_single_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // (n, m) = (2, 1)
+        let mut rng = ChaChaRng::from_entropy();
+        let total_output = 50 + rng.next_u64() % 50;
+        let amount = rng.next_u64() % total_output;
+        let inputs = vec![(amount, zero), (total_output - amount, zero)];
+        let outputs = vec![(total_output, zero)];
+        test_anon_xfr_proof_with_fees(outputs, inputs);
+    }
+
+    #[test]
     fn test_anon_multi_xfr_proof_1in_1out_single_asset() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 1)
@@ -289,6 +301,18 @@ mod tests {
         let inputs = vec![(amount, zero)];
         let outputs = vec![(amount, zero)];
         test_anon_xfr_proof(outputs, inputs);
+    }
+
+    #[test]
+    fn test_anon_multi_xfr_proof_1in_1out_single_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // (n, m) = (1, 1)
+
+        let mut rng = ChaChaRng::from_entropy();
+        let amount = 50 + rng.next_u64() % 50;
+        let inputs = vec![(amount, zero)];
+        let outputs = vec![(amount, zero)];
+        test_anon_xfr_proof_with_fees(outputs, inputs);
     }
 
     #[test]
@@ -326,6 +350,43 @@ mod tests {
         outputs.push((total_output_zero, zero));
 
         test_anon_xfr_proof(inputs, outputs);
+    }
+
+    #[test]
+    fn test_anon_multi_xfr_proof_3in_6out_multi_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // multiple asset types
+        // (n, m) = (3, 6)
+        let one = BLSScalar::one();
+
+        let mut rng = ChaChaRng::from_entropy();
+        let total_input_zero = 50 + rng.next_u64() % 50;
+        let amount_zero = rng.next_u64() % total_input_zero;
+        let total_input_one = 50 + rng.next_u64() % 50;
+
+        let mut total_output_zero = total_input_zero;
+        let mut total_output_one = total_input_one;
+
+        let inputs = vec![
+            (/*amount=*/ amount_zero, /*asset_type=*/ zero),
+            (total_input_one, one),
+            (total_input_zero - amount_zero, zero),
+        ];
+
+        let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
+
+        for _i in 1..3 {
+            let amount_one = rng.next_u64() % total_output_one;
+            let amount_zero = rng.next_u64() % total_output_zero;
+            outputs.push((amount_one, one));
+            outputs.push((amount_zero, zero));
+            total_output_one -= amount_one;
+            total_output_zero -= amount_zero;
+        }
+        outputs.push((total_output_one, one));
+        outputs.push((total_output_zero, zero));
+
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -226,6 +226,36 @@ mod tests {
     }
 
     #[test]
+    fn test_anon_multi_xfr_proof_3in_6out_single_asset_with_fees() {
+        // single asset type
+        let zero = BLSScalar::zero();
+
+        let mut rng = ChaChaRng::from_entropy();
+        let mut total_input = 50 + rng.next_u64() % 50;
+        let mut total_output = total_input;
+
+        let mut inputs: Vec<(u64, BLSScalar)> = Vec::new();
+        for _i in 1..3 {
+            let rnd_amount = rng.next_u64();
+            let amount = rnd_amount % total_input;
+            inputs.push((amount, zero));
+            total_input -= amount;
+        }
+        inputs.push((total_input, zero));
+
+        let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
+        for _i in 1..6 {
+            let rnd_amount = rng.next_u64();
+            let amount = rnd_amount % total_output;
+            outputs.push((amount, zero));
+            total_output -= amount;
+        }
+        outputs.push((total_output, zero));
+
+        test_anon_xfr_proof_with_fees(inputs, outputs);
+    }
+
+    #[test]
     fn test_anon_multi_xfr_proof_3in_3out_single_asset() {
         let zero = BLSScalar::zero();
         // (n, m) = (3, 3)
@@ -256,6 +286,36 @@ mod tests {
     }
 
     #[test]
+    fn test_anon_multi_xfr_proof_3in_3out_single_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // (n, m) = (3, 3)
+
+        let mut rng = ChaChaRng::from_entropy();
+        let mut total_input = 50 + rng.next_u64() % 50;
+
+        let mut total_output = total_input;
+
+        let mut inputs: Vec<(u64, BLSScalar)> = Vec::new();
+
+        let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
+
+        for _i in 1..3 {
+            let amount = rng.next_u64() % total_input;
+            inputs.push((amount, zero));
+            total_input -= amount;
+
+            let amount_out = rng.next_u64() % total_output;
+            outputs.push((amount_out, zero));
+            total_output -= amount_out;
+        }
+
+        inputs.push((total_input, zero));
+        outputs.push((total_output, zero));
+
+        test_anon_xfr_proof_with_fees(outputs, inputs);
+    }
+
+    #[test]
     fn test_anon_multi_xfr_proof_1in_2out_single_asset() {
         let zero = BLSScalar::zero();
         // (n, m) = (1, 2)
@@ -265,6 +325,18 @@ mod tests {
         let amount = rng.next_u64() % total_input;
         let outputs = vec![(amount, zero), (total_input - amount, zero)];
         test_anon_xfr_proof(inputs.to_vec(), outputs.to_vec());
+    }
+
+    #[test]
+    fn test_anon_multi_xfr_proof_1in_2out_single_asset_with_fees() {
+        let zero = BLSScalar::zero();
+        // (n, m) = (1, 2)
+        let mut rng = ChaChaRng::from_entropy();
+        let total_input = 50 + rng.next_u64() % 50;
+        let inputs = vec![(total_input, zero)];
+        let amount = rng.next_u64() % total_input;
+        let outputs = vec![(amount, zero), (total_input - amount, zero)];
+        test_anon_xfr_proof_with_fees(inputs.to_vec(), outputs.to_vec());
     }
 
     #[test]

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -262,7 +262,7 @@ mod tests {
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_single_asset() {
         let zero = BLSScalar::zero();
@@ -291,7 +291,7 @@ mod tests {
         outputs.push((total_output, zero));
 
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
 
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_single_asset_with_fees() {
@@ -546,7 +546,7 @@ mod tests {
     }
      
     //original test
-    
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_multi_asset_with_fees_old() {
         let zero = BLSScalar::zero();
@@ -579,8 +579,8 @@ mod tests {
         inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
-    }
-
+    }*/
+    /* 
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_multi_asset() {
         let zero = BLSScalar::zero();
@@ -607,7 +607,7 @@ mod tests {
         ];
 
         test_anon_xfr_proof(inputs, outputs);
-    }
+    }*/
 
     /*
     This function computes the fees for all the test with fees, however it might be better if

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -41,6 +41,9 @@ pub(crate) fn prove_xfr_with_fees<R: CryptoRng + RngCore>(
         secret_inputs.payees_secrets.len() as u64,
     );
 
+    let x = 2u32;
+    let y = 2u32;
+
     let fee_type = BLSScalar::from_u32(000u32);
     
     let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -1,10 +1,11 @@
 use crate::anon_xfr::circuits::{
-    build_eq_committed_vals_cs, build_multi_xfr_cs, build_multi_xfr_cs_with_fees, AMultiXfrPubInputs, AMultiXfrWitness,
+    build_eq_committed_vals_cs, build_multi_xfr_cs, build_multi_xfr_cs_with_fees,
+    AMultiXfrPubInputs, AMultiXfrWitness,
 };
 use crate::setup::{NodeParams, UserParams};
 //use algebra::groups::{Scalar, Zero};
-use algebra::groups::{Zero};
 use algebra::bls12_381::BLSScalar;
+use algebra::groups::Zero;
 use algebra::jubjub::JubjubPoint;
 use crypto::basics::commitments::pedersen::PedersenGens;
 use merlin::Transcript;
@@ -44,10 +45,11 @@ pub(crate) fn prove_xfr_with_fees<R: CryptoRng + RngCore>(
 
     //let fee_type = BLSScalar::from_u32(000u32);
     let fee_type = BLSScalar::zero();
-    
+
     let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
 
-    let (mut cs, _) = build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
+    let (mut cs, _) =
+        build_multi_xfr_cs_with_fees(secret_inputs, fee_type, &fee_calculating_func);
     let witness = cs.get_and_clear_witness();
 
     prover(
@@ -186,7 +188,8 @@ mod tests {
     use crate::anon_xfr::circuits::tests::new_multi_xfr_witness_for_test;
     use crate::anon_xfr::circuits::AMultiXfrPubInputs;
     use crate::anon_xfr::proofs::{
-        prove_eq_committed_vals, prove_xfr, prove_xfr_with_fees, verify_eq_committed_vals, verify_xfr,
+        prove_eq_committed_vals, prove_xfr, prove_xfr_with_fees,
+        verify_eq_committed_vals, verify_xfr,
     };
     use crate::setup::{NodeParams, UserParams, DEFAULT_BP_NUM_GENS};
     use algebra::bls12_381::BLSScalar;
@@ -198,7 +201,7 @@ mod tests {
     use rand_chacha::ChaChaRng;
     use rand_core::SeedableRng;
 
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_single_asset() {
         // single asset type
@@ -246,7 +249,6 @@ mod tests {
         total_input -= amount;
         inputs.push((total_input, zero));
 
-
         let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
         for _i in 1..6 {
             let rnd_amount = rng.next_u64();
@@ -256,13 +258,12 @@ mod tests {
         }
         outputs.push((total_output, zero));
 
-
-        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(inputs.len() as u64 + 1, outputs.len() as u64);
         inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_single_asset() {
         let zero = BLSScalar::zero();
@@ -311,8 +312,6 @@ mod tests {
         total_input -= amount;
         inputs.push((total_input, zero));
 
-
-
         let amount_out = rng.next_u64() % total_output;
         outputs.push((amount_out, zero));
         total_output -= amount_out;
@@ -320,12 +319,12 @@ mod tests {
 
         //input for fees
         //Base fee 5 + 1 * (inputs) + 2 * (outputs)
-        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(inputs.len() as u64 + 1, outputs.len() as u64);
         inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_1in_2out_single_asset() {
         let zero = BLSScalar::zero();
@@ -347,13 +346,13 @@ mod tests {
         let outputs = vec![(amount, zero), (amount, zero)];
 
         //Base fee 5 + 1 * (inputs) + 2 * (outputs)
-        let fee_amount = compute_fees(1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(1, outputs.len() as u64);
 
         let inputs = vec![(fee_amount, zero)];
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_2in_1out_single_asset() {
         let zero = BLSScalar::zero();
@@ -376,16 +375,15 @@ mod tests {
         //This time we need one input equal to the output, besides the input for fees
         let amount = 50 + rng.next_u64() % 50; // a random number in [50, 100)
 
-
         let outputs = vec![(amount, zero)];
         let mut inputs = vec![(amount, zero)];
 
-        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(inputs.len() as u64 + 1, outputs.len() as u64);
         inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_1in_1out_single_asset() {
         let zero = BLSScalar::zero();
@@ -410,7 +408,7 @@ mod tests {
         let outputs = vec![(0, zero)];
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_3in_6out_multi_asset() {
         let zero = BLSScalar::zero();
@@ -476,10 +474,7 @@ mod tests {
         let mut total_output_zero = total_input_zero;
         let mut total_output_one = total_input_one;*/
 
-        let mut inputs = vec![
-            (/*amount=*/ 40, /*asset_type=*/ zero),
-            (80, one),
-        ];
+        let mut inputs = vec![(/*amount=*/ 40, /*asset_type=*/ zero), (80, one)];
 
         /*let mut outputs: Vec<(u64, BLSScalar)> = Vec::new();
 
@@ -501,13 +496,12 @@ mod tests {
             (20, one),
             (20, one),
             (40, one),
-
         ];
 
-        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(inputs.len() as u64 + 1, outputs.len() as u64);
         inputs.push((fee_amount, zero));
 
-        test_anon_xfr_proof_with_fees (inputs, outputs);
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     // dummy new test
@@ -520,33 +514,24 @@ mod tests {
         let input_1 = 20u64;
         let input_2 = 52u64;
 
-
         let output_1 = 17u64;
         let output_2 = 3u64;
         let output_3 = 52u64;
 
-
         //let input_fees = 5 + (3 * 1) + (3 * 2);
 
-        let mut inputs = vec![
-            (input_1, zero),
-            (input_2, one),
-        ];
+        let mut inputs = vec![(input_1, zero), (input_2, one)];
 
-        let outputs = vec![
-            (output_1, zero),
-            (output_2, zero),
-            (output_3, one),
-        ];
+        let outputs = vec![(output_1, zero), (output_2, zero), (output_3, one)];
 
-        let fee_amount = compute_fees (inputs.len() as u64 + 1 ,outputs.len() as u64);
+        let fee_amount = compute_fees(inputs.len() as u64 + 1, outputs.len() as u64);
         inputs.push((fee_amount, zero));
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }
-     
+
     //original test
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_multi_asset_with_fees_old() {
         let zero = BLSScalar::zero();
@@ -580,7 +565,7 @@ mod tests {
 
         test_anon_xfr_proof_with_fees(inputs, outputs);
     }*/
-    /* 
+    /*
     #[test]
     fn test_anon_multi_xfr_proof_3in_3out_multi_asset() {
         let zero = BLSScalar::zero();
@@ -617,7 +602,7 @@ mod tests {
     c_0 + c_1 * inputs + c_2 * outputs
     where c_0 = 5; c_1 = 1 and c_2 = 2
     */
-    fn compute_fees(num_inputs:u64, num_outputs:u64) -> u64{
+    fn compute_fees(num_inputs: u64, num_outputs: u64) -> u64 {
         //let fee_calculating_func = |x: u64, y: u64| 5 + x + 2 * y;
         5 + num_inputs + 2 * num_outputs
     }
@@ -648,7 +633,8 @@ mod tests {
         // A bad proof should fail the verification
         let bad_secret_inputs =
             new_multi_xfr_witness_for_test(inputs, outputs, [1u8; 32]);
-        let bad_proof = prove_xfr_with_fees(&mut prng, &params, bad_secret_inputs).unwrap();
+        let bad_proof =
+            prove_xfr_with_fees(&mut prng, &params, bad_secret_inputs).unwrap();
 
         // verify good witness
         let node_params = NodeParams::from(params);
@@ -657,7 +643,7 @@ mod tests {
         // verify bad witness
         assert!(verify_xfr(&node_params, &pub_inputs, &bad_proof).is_err());
     }
-    
+
     fn test_anon_xfr_proof(
         inputs: Vec<(u64, BLSScalar)>,
         outputs: Vec<(u64, BLSScalar)>,

--- a/zei_api/src/anon_xfr/proofs.rs
+++ b/zei_api/src/anon_xfr/proofs.rs
@@ -348,6 +348,7 @@ mod tests {
         let amount = rng.next_u64() % total_output;
         let inputs = vec![(amount, zero), (total_output - amount, zero)];
         let outputs = vec![(total_output, zero)];
+        //test_anon_xfr_proof(outputs, inputs);
         test_anon_xfr_proof(outputs, inputs);
     }
 
@@ -370,7 +371,9 @@ mod tests {
         //let inputs = vec![(amount, zero), (total_output - amount, zero)];
         let inputs = vec![(amount, zero), (fees_input, zero)];
 
-        test_anon_xfr_proof_with_fees(outputs, inputs);
+        //test_anon_xfr_proof_with_fees(outputs, inputs);
+        //This fix the error we were putting the parameters in the wrong way
+        test_anon_xfr_proof_with_fees(inputs, outputs);
     }
 
     #[test]

--- a/zei_api/src/lib.rs
+++ b/zei_api/src/lib.rs
@@ -2,7 +2,7 @@
 //! Zei: Findora's cryptographic library
 //!
 
-#![deny(warnings)]
+//#![deny(warnings)]
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::bool_assert_comparison)]

--- a/zei_api/src/lib.rs
+++ b/zei_api/src/lib.rs
@@ -2,7 +2,7 @@
 //! Zei: Findora's cryptographic library
 //!
 
-//#![deny(warnings)]
+#![deny(warnings)]
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::bool_assert_comparison)]

--- a/zei_api/src/setup.rs
+++ b/zei_api/src/setup.rs
@@ -1,10 +1,11 @@
 //The Public Setup needed for Proofs
 use crate::anon_xfr::circuits::{
-    build_eq_committed_vals_cs, build_multi_xfr_cs, AMultiXfrWitness,
-    TurboPlonkCS, TREE_DEPTH,
+    build_eq_committed_vals_cs, build_multi_xfr_cs, AMultiXfrWitness, TurboPlonkCS,
+    TREE_DEPTH,
 };
 use algebra::bls12_381::BLSScalar;
-use algebra::groups::Scalar;
+
+use crate::anon_xfr::config::{FEE_CALCULATING_FUNC, FEE_TYPE};
 use algebra::groups::Zero;
 use algebra::jubjub::JubjubPoint;
 use bulletproofs::BulletproofGens;
@@ -22,7 +23,6 @@ use std::fs;
 use std::path::PathBuf;
 use utils::errors::ZeiError;
 use utils::save_to_file;
-use crate::anon_xfr::config::{FEE_CALCULATING_FUNC, FEE_TYPE};
 
 //Shared by all members of the ledger
 #[derive(Serialize, Deserialize)]

--- a/zei_api/src/setup.rs
+++ b/zei_api/src/setup.rs
@@ -1,10 +1,10 @@
 //The Public Setup needed for Proofs
 use crate::anon_xfr::circuits::{
-    build_eq_committed_vals_cs, build_multi_xfr_cs_with_fees, AMultiXfrWitness, TurboPlonkCS,
-    TREE_DEPTH,
+    build_eq_committed_vals_cs, build_multi_xfr_cs_with_fees, AMultiXfrWitness,
+    TurboPlonkCS, TREE_DEPTH,
 };
-use algebra::groups::Scalar;
 use algebra::bls12_381::BLSScalar;
+use algebra::groups::Scalar;
 use algebra::groups::Zero;
 use algebra::jubjub::JubjubPoint;
 use bulletproofs::BulletproofGens;
@@ -120,7 +120,6 @@ impl Default for PublicParams {
 }
 
 impl UserParams {
-
     /*pub fn new(
         n_payers: usize,
         n_payees: usize,
@@ -156,20 +155,23 @@ impl UserParams {
         tree_depth: Option<usize>,
         bp_num_gens: usize,
     ) -> UserParams {
-
         let _x = 2u32;
         let _y = 2u32;
 
         let fee_type = BLSScalar::from_u32(000u32);
-    
+
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
         let (cs, n_constraints) = match tree_depth {
-            Some(depth) => {
-                build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(n_payers, n_payees, depth), fee_type, &fee_calculating_func)
-            }
-            None => build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(
-                n_payers, n_payees, TREE_DEPTH,
-            ), fee_type, &fee_calculating_func),
+            Some(depth) => build_multi_xfr_cs_with_fees(
+                AMultiXfrWitness::fake(n_payers, n_payees, depth),
+                fee_type,
+                &fee_calculating_func,
+            ),
+            None => build_multi_xfr_cs_with_fees(
+                AMultiXfrWitness::fake(n_payers, n_payees, TREE_DEPTH),
+                fee_type,
+                &fee_calculating_func,
+            ),
         };
 
         let pcs = KZGCommitmentScheme::new(
@@ -185,7 +187,6 @@ impl UserParams {
             prover_params,
         }
     }
-        
 
     //This function is the same that new, but max_degree_poly_com allows to set the size of the CRS
     //the parameter max_degree_poly_com is padded to the minimum power of two grater than it.
@@ -197,7 +198,7 @@ impl UserParams {
         max_degree_poly_com: usize,
     ) -> UserParams {
 
-        
+
         let (cs, /*n_constrains*/ _) = match tree_depth {
             Some(depth) => {
                 build_multi_xfr_cs(AMultiXfrWitness::fake(n_payers, n_payees, depth))
@@ -230,20 +231,23 @@ impl UserParams {
         bp_num_gens: usize,
         max_degree_poly_com: usize,
     ) -> UserParams {
-
         let _x = 2u32;
         let _y = 2u32;
 
         let fee_type = BLSScalar::from_u32(000u32);
-    
+
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
         let (cs, /*n_constrains*/ _) = match tree_depth {
-            Some(depth) => {
-                build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(n_payers, n_payees, depth), fee_type, &fee_calculating_func)
-            }
-            None => build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(
-                n_payers, n_payees, TREE_DEPTH,
-            ), fee_type, &fee_calculating_func),
+            Some(depth) => build_multi_xfr_cs_with_fees(
+                AMultiXfrWitness::fake(n_payers, n_payees, depth),
+                fee_type,
+                &fee_calculating_func,
+            ),
+            None => build_multi_xfr_cs_with_fees(
+                AMultiXfrWitness::fake(n_payers, n_payees, TREE_DEPTH),
+                fee_type,
+                &fee_calculating_func,
+            ),
         };
 
         let max_degree_poly_com = max_degree_poly_com.next_power_of_two();

--- a/zei_api/src/setup.rs
+++ b/zei_api/src/setup.rs
@@ -157,6 +157,9 @@ impl UserParams {
         bp_num_gens: usize,
     ) -> UserParams {
 
+        let _x = 2u32;
+        let _y = 2u32;
+
         let fee_type = BLSScalar::from_u32(000u32);
     
         let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
@@ -227,6 +230,9 @@ impl UserParams {
         bp_num_gens: usize,
         max_degree_poly_com: usize,
     ) -> UserParams {
+
+        let _x = 2u32;
+        let _y = 2u32;
 
         let fee_type = BLSScalar::from_u32(000u32);
     

--- a/zei_api/src/setup.rs
+++ b/zei_api/src/setup.rs
@@ -1,8 +1,9 @@
 //The Public Setup needed for Proofs
 use crate::anon_xfr::circuits::{
-    build_eq_committed_vals_cs, build_multi_xfr_cs, AMultiXfrWitness, TurboPlonkCS,
+    build_eq_committed_vals_cs, build_multi_xfr_cs_with_fees, AMultiXfrWitness, TurboPlonkCS,
     TREE_DEPTH,
 };
+use algebra::groups::Scalar;
 use algebra::bls12_381::BLSScalar;
 use algebra::groups::Zero;
 use algebra::jubjub::JubjubPoint;
@@ -119,7 +120,8 @@ impl Default for PublicParams {
 }
 
 impl UserParams {
-    pub fn new(
+
+    /*pub fn new(
         n_payers: usize,
         n_payees: usize,
         tree_depth: Option<usize>,
@@ -146,17 +148,53 @@ impl UserParams {
             cs,
             prover_params,
         }
+    }*/
+
+    pub fn new(
+        n_payers: usize,
+        n_payees: usize,
+        tree_depth: Option<usize>,
+        bp_num_gens: usize,
+    ) -> UserParams {
+
+        let fee_type = BLSScalar::from_u32(000u32);
+    
+        let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
+        let (cs, n_constraints) = match tree_depth {
+            Some(depth) => {
+                build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(n_payers, n_payees, depth), fee_type, &fee_calculating_func)
+            }
+            None => build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(
+                n_payers, n_payees, TREE_DEPTH,
+            ), fee_type, &fee_calculating_func),
+        };
+
+        let pcs = KZGCommitmentScheme::new(
+            n_constraints + 2,
+            &mut ChaChaRng::from_seed([0u8; 32]),
+        );
+
+        let prover_params = preprocess_prover(&cs, &pcs, COMMON_SEED).unwrap();
+        UserParams {
+            bp_params: PublicParams::new(bp_num_gens),
+            pcs,
+            cs,
+            prover_params,
+        }
     }
+        
 
     //This function is the same that new, but max_degree_poly_com allows to set the size of the CRS
     //the parameter max_degree_poly_com is padded to the minimum power of two grater than it.
-    pub fn new_max_degree_poly_com(
+    /*pub fn new_max_degree_poly_com(
         n_payers: usize,
         n_payees: usize,
         tree_depth: Option<usize>,
         bp_num_gens: usize,
         max_degree_poly_com: usize,
     ) -> UserParams {
+
+        
         let (cs, /*n_constrains*/ _) = match tree_depth {
             Some(depth) => {
                 build_multi_xfr_cs(AMultiXfrWitness::fake(n_payers, n_payees, depth))
@@ -164,6 +202,42 @@ impl UserParams {
             None => build_multi_xfr_cs(AMultiXfrWitness::fake(
                 n_payers, n_payees, TREE_DEPTH,
             )),
+        };
+
+        let max_degree_poly_com = max_degree_poly_com.next_power_of_two();
+
+        let pcs = KZGCommitmentScheme::new(
+            max_degree_poly_com + 2,
+            &mut ChaChaRng::from_seed([0u8; 32]),
+        );
+
+        let prover_params = preprocess_prover(&cs, &pcs, COMMON_SEED).unwrap();
+        UserParams {
+            bp_params: PublicParams::new(bp_num_gens),
+            pcs,
+            cs,
+            prover_params,
+        }
+    }*/
+
+    pub fn new_max_degree_poly_com(
+        n_payers: usize,
+        n_payees: usize,
+        tree_depth: Option<usize>,
+        bp_num_gens: usize,
+        max_degree_poly_com: usize,
+    ) -> UserParams {
+
+        let fee_type = BLSScalar::from_u32(000u32);
+    
+        let fee_calculating_func = |x: u32, y: u32| 5 + x + 2 * y;
+        let (cs, /*n_constrains*/ _) = match tree_depth {
+            Some(depth) => {
+                build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(n_payers, n_payees, depth), fee_type, &fee_calculating_func)
+            }
+            None => build_multi_xfr_cs_with_fees(AMultiXfrWitness::fake(
+                n_payers, n_payees, TREE_DEPTH,
+            ), fee_type, &fee_calculating_func),
         };
 
         let max_degree_poly_com = max_degree_poly_com.next_power_of_two();


### PR DESCRIPTION
Edited by findora-crypto:

This PR updates the existing tests for the asset mixing with fees. A candidate fee policy is also specified in this PR: the fee would be FRA, and the amount being charged is 0.5 FRA + 0.1 FRA/input + 0.2 FRA/output, subject to adjustment in the future.