### PR TITLE
Optimize merkle tree storage size

### DIFF
--- a/accumulators/src/lib.rs
+++ b/accumulators/src/lib.rs
@@ -5,39 +5,30 @@ mod tests {
     use crate::merkle_tree::PersistentMerkleTree;
     use algebra::bls12_381::BLSScalar;
     use algebra::groups::One;
-    use crypto::basics::hash::rescue::RescueInstance;
     use parking_lot::RwLock;
     use std::sync::Arc;
     use std::thread;
+    use std::time::Instant;
     use storage::db::TempRocksDB;
     use storage::state::{ChainState, State};
     use storage::store::PrefixedStore;
 
     #[test]
-    fn test() {
-        let _hash = RescueInstance::new();
-
+    fn test_merkle_tree() {
         let path = thread::current().name().unwrap().to_owned();
         let fdb = TempRocksDB::open(path).expect("failed to open db");
         let cs = Arc::new(RwLock::new(ChainState::new(fdb, "test_db".to_string(), 0)));
         let mut state = State::new(cs, false);
         let store = PrefixedStore::new("my_store", &mut state);
         let mut mt = PersistentMerkleTree::new(store).unwrap();
-        //let root0 = mt.get_current_root_hash().unwrap();
-        //assert_eq!(root0, BLSScalar::zero());
 
-        let sid_0 = mt.add_commitment_hash(BLSScalar::one()).unwrap();
-        assert_eq!(sid_0, 0);
-
-        let v0 = mt.commit().unwrap();
-        let proof0 = mt.generate_proof(0).unwrap();
-        println!("nodes: {:?}", proof0.nodes.len()); // 1856 vs 492
-        println!("root: {:?}", proof0.root);
-        // root: BLSScalar(BigInt([4455513758586644197, 9240243640558842050, 15041668979369452445, 5894806090397613214]))
-        // root: BLSScalar(BigInt([17393346530685615531, 10665263640234564765, 10406422131025996151, 3117343432492655840]))
-        // root: BLSScalar(BigInt([11070693654976930170, 17319180623281640354, 839506441540242814, 4948558268637580532]))
-        println!("root_verison: {:?}", proof0.root_version);
-        println!("uid: {:?}", proof0.uid);
-        assert_eq!(proof0.root_version as u64, v0);
+        let start = Instant::now();
+        for _ in 0..10 {
+            let sid_0 = mt.add_commitment_hash(BLSScalar::one()).unwrap();
+            let proof0 = mt.generate_proof(sid_0).unwrap();
+            assert_eq!(proof0.uid, sid_0);
+        }
+        let end = start.elapsed();
+        println!("Time: {:?} microseconds", end.as_micros());
     }
 }

--- a/accumulators/src/lib.rs
+++ b/accumulators/src/lib.rs
@@ -2,7 +2,7 @@ pub mod merkle_tree;
 
 #[cfg(test)]
 mod tests {
-    use crate::merkle_tree::PersistentMerkleTree;
+    use crate::merkle_tree::{verify, PersistentMerkleTree};
     use algebra::bls12_381::BLSScalar;
     use algebra::groups::One;
     use parking_lot::RwLock;
@@ -27,8 +27,17 @@ mod tests {
             let sid_0 = mt.add_commitment_hash(BLSScalar::one()).unwrap();
             let proof0 = mt.generate_proof(sid_0).unwrap();
             assert_eq!(proof0.uid, sid_0);
+            assert!(verify(BLSScalar::one(), &proof0));
         }
         let end = start.elapsed();
         println!("Time: {:?} microseconds", end.as_micros());
+
+        let sid_x = mt.add_commitment_hash(BLSScalar::one()).unwrap();
+        let proofx = mt.generate_proof_with_depth(sid_x, 10).unwrap();
+        assert!(verify(BLSScalar::one(), &proofx));
+        let proof4 = mt.generate_proof_with_depth(sid_x, 32).unwrap();
+        assert!(verify(BLSScalar::one(), &proof4));
+        assert!(mt.generate_proof_with_depth(sid_x, 41).is_err());
+        assert!(mt.generate_proof_with_depth(sid_x, 2).is_err());
     }
 }

--- a/accumulators/src/lib.rs
+++ b/accumulators/src/lib.rs
@@ -1,1 +1,43 @@
 pub mod merkle_tree;
+
+#[cfg(test)]
+mod tests {
+    use crate::merkle_tree::PersistentMerkleTree;
+    use algebra::bls12_381::BLSScalar;
+    use algebra::groups::One;
+    use crypto::basics::hash::rescue::RescueInstance;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+    use std::thread;
+    use storage::db::TempRocksDB;
+    use storage::state::{ChainState, State};
+    use storage::store::PrefixedStore;
+
+    #[test]
+    fn test() {
+        let _hash = RescueInstance::new();
+
+        let path = thread::current().name().unwrap().to_owned();
+        let fdb = TempRocksDB::open(path).expect("failed to open db");
+        let cs = Arc::new(RwLock::new(ChainState::new(fdb, "test_db".to_string(), 0)));
+        let mut state = State::new(cs, false);
+        let store = PrefixedStore::new("my_store", &mut state);
+        let mut mt = PersistentMerkleTree::new(store).unwrap();
+        //let root0 = mt.get_current_root_hash().unwrap();
+        //assert_eq!(root0, BLSScalar::zero());
+
+        let sid_0 = mt.add_commitment_hash(BLSScalar::one()).unwrap();
+        assert_eq!(sid_0, 0);
+
+        let v0 = mt.commit().unwrap();
+        let proof0 = mt.generate_proof(0).unwrap();
+        println!("nodes: {:?}", proof0.nodes.len()); // 1856 vs 492
+        println!("root: {:?}", proof0.root);
+        // root: BLSScalar(BigInt([4455513758586644197, 9240243640558842050, 15041668979369452445, 5894806090397613214]))
+        // root: BLSScalar(BigInt([17393346530685615531, 10665263640234564765, 10406422131025996151, 3117343432492655840]))
+        // root: BLSScalar(BigInt([11070693654976930170, 17319180623281640354, 839506441540242814, 4948558268637580532]))
+        println!("root_verison: {:?}", proof0.root_version);
+        println!("uid: {:?}", proof0.uid);
+        assert_eq!(proof0.root_version as u64, v0);
+    }
+}

--- a/accumulators/src/merkle_tree.rs
+++ b/accumulators/src/merkle_tree.rs
@@ -12,17 +12,13 @@ use utils::serialization::ZeiFromToBytes;
 // 3^0 + 3^1 + 3^2 + ... 3^40 < 2^64 (u64 can include all leaf & ancestor)
 // store max is 3^40 = 12157665459056928801
 // sid   max is 2^64 = 18446744073709551616
-const TREE_DEPTH: usize = 40;
+pub const TREE_DEPTH: usize = 40;
+// 6078832729528464400 = 3^0 + 3^1 + 3^2 + ... 3^39, if change TREE_DEPTH, MUST update.
+const LEAF_START: u64 = 6078832729528464400;
 
 const KEY_PAD: [u8; 4] = [0, 0, 0, 0];
 const ROOT_KEY: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // KEY_PAD + 0u64
 const ENTRY_COUNT_KEY: [u8; 4] = [0, 0, 0, 1];
-
-// 6078832729528464400 = 3^0 + 3^1 + 3^2 + ... 3^39
-const LEAF_START: u64 = 6078832729528464400;
-
-//const BASE_KEY: &str = "dense_merkle_tree:root:";
-//const ENTRY_COUNT_KEY: &str = "dense_merkle_tree:entrycount:";
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Path {
@@ -35,7 +31,7 @@ pub enum Path {
 /// PersistentMerkleTree is a 3-ary merkle tree
 ///
 /// Usage:
-///    ```
+///    ```ignore
 ///     use std::collections::HashMap;
 ///     use std::thread;
 ///     use storage::db::TempRocksDB;

--- a/accumulators/src/merkle_tree.rs
+++ b/accumulators/src/merkle_tree.rs
@@ -115,7 +115,7 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
                 }
                 let mut store_key = KEY_PAD.to_vec();
                 store_key.extend(key.to_be_bytes());
-                match self.get(&store_key).unwrap() {
+                match self.get(&store_key)? {
                     Some(b) => BLSScalar::zei_from_bytes(b.as_slice()),
                     None => Ok(BLSScalar::zero()),
                 }
@@ -161,11 +161,12 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
 
         let nodes: Vec<ProofNode> = keys[0..TREE_DEPTH]
             .iter()
+            .rev()
             .map(|(key, path)| {
                 // if current node is not present in store then it is not a valid uid to generate
                 let mut store_key = KEY_PAD.to_vec();
                 store_key.extend(key.to_be_bytes());
-                if !self.store.exists(&store_key).unwrap() {
+                if !self.store.exists(&store_key)? {
                     return Err(eg!("uid not found in tree, cannot generate proof"));
                 }
 
@@ -189,12 +190,12 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
                 };
                 let mut store_key1 = KEY_PAD.to_vec();
                 store_key1.extend(sib1.to_be_bytes());
-                if let Some(b) = self.store.get(&store_key1).unwrap() {
+                if let Some(b) = self.store.get(&store_key1)? {
                     node.siblings1 = BLSScalar::zei_from_bytes(b.as_slice())?;
                 }
                 let mut store_key2 = KEY_PAD.to_vec();
                 store_key2.extend(sib2.to_be_bytes());
-                if let Some(b) = self.store.get(&store_key2).unwrap() {
+                if let Some(b) = self.store.get(&store_key2)? {
                     node.siblings2 = BLSScalar::zei_from_bytes(b.as_slice())?;
                 }
 
@@ -204,14 +205,14 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
 
         Ok(Proof {
             nodes: nodes,
-            root: self.get_current_root_hash().unwrap(),
+            root: self.get_current_root_hash()?,
             root_version: 1,
             uid: id,
         })
     }
 
     pub fn get_current_root_hash(&self) -> Result<BLSScalar> {
-        match self.store.get(&ROOT_KEY).unwrap() {
+        match self.store.get(&ROOT_KEY)? {
             Some(hash) => BLSScalar::zei_from_bytes(hash.as_slice()),
             None => Err(eg!("root hash key not found")),
         }
@@ -294,7 +295,7 @@ impl<'a, D: MerkleDB> ImmutablePersistentMerkleTree<'a, D> {
                 // if current node is not present in store then it is not a valid uid to generate
                 let mut store_key = KEY_PAD.to_vec();
                 store_key.extend(key.to_be_bytes());
-                if !self.store.exists(&store_key).unwrap() {
+                if !self.store.exists(&store_key)? {
                     return Err(eg!("uid not found in tree, cannot generate proof"));
                 }
 
@@ -318,12 +319,12 @@ impl<'a, D: MerkleDB> ImmutablePersistentMerkleTree<'a, D> {
                 };
                 let mut store_key1 = KEY_PAD.to_vec();
                 store_key1.extend(sib1.to_be_bytes());
-                if let Some(b) = self.store.get(&store_key1).unwrap() {
+                if let Some(b) = self.store.get(&store_key1)? {
                     node.siblings1 = BLSScalar::zei_from_bytes(b.as_slice())?;
                 }
                 let mut store_key2 = KEY_PAD.to_vec();
                 store_key2.extend(sib2.to_be_bytes());
-                if let Some(b) = self.store.get(&store_key2).unwrap() {
+                if let Some(b) = self.store.get(&store_key2)? {
                     node.siblings2 = BLSScalar::zei_from_bytes(b.as_slice())?;
                 }
 
@@ -333,7 +334,7 @@ impl<'a, D: MerkleDB> ImmutablePersistentMerkleTree<'a, D> {
 
         Ok(Proof {
             nodes: nodes,
-            root: self.get_current_root_hash().unwrap(),
+            root: self.get_current_root_hash()?,
             root_version: 1,
             uid: id,
         })

--- a/accumulators/src/merkle_tree.rs
+++ b/accumulators/src/merkle_tree.rs
@@ -10,8 +10,8 @@ use utils::serialization::ZeiFromToBytes;
 
 // ceil(log(u64::MAX, 3)) = 41
 // 3^0 + 3^1 + 3^2 + ... 3^40 < 2^64 (u64 can include all leaf & ancestor)
-// store max is 3^40 = 12157665459056928801
-// sid   max is 2^64 = 18446744073709551616
+// store max num is 3^40 = 12157665459056928801 (max uid = 3^40 - 1)
+// sid   max num is 2^64 = 18446744073709551616 (max uid = 2^64 - 1)
 pub const TREE_DEPTH: usize = 40;
 // 6078832729528464400 = 3^0 + 3^1 + 3^2 + ... 3^39, if change TREE_DEPTH, MUST update.
 const LEAF_START: u64 = 6078832729528464400;
@@ -466,4 +466,99 @@ fn get_path_keys(uid: u64) -> Vec<(u64, TreePath)> {
         }
     }
     keys
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{get_path_keys, TreePath};
+
+    #[test]
+    fn test_merkle_tree_path() {
+        let first_keys = get_path_keys(0);
+        let mut first_sum = 0u64;
+        for (i, (key, path)) in
+            first_keys[0..first_keys.len() - 1].iter().rev().enumerate()
+        {
+            first_sum += 3u64.pow(i as u32);
+            assert_eq!(*key, first_sum);
+            assert_eq!(*path, TreePath::Left);
+        }
+
+        let mut t1 = get_path_keys(1);
+        t1.pop(); // pop root.
+        assert_eq!(t1[0].1, TreePath::Middle);
+        for (_, path) in &t1[1..] {
+            assert_eq!(*path, TreePath::Left);
+        }
+
+        let mut t2 = get_path_keys(2);
+        t2.pop();
+        assert_eq!(t2[0].1, TreePath::Right);
+        for (_, path) in &t2[1..] {
+            assert_eq!(*path, TreePath::Left);
+        }
+
+        let mut t3 = get_path_keys(3);
+        t3.pop();
+        assert_eq!(t3[0].1, TreePath::Left);
+        assert_eq!(t3[1].1, TreePath::Middle);
+        for (_, path) in &t3[2..] {
+            assert_eq!(*path, TreePath::Left);
+        }
+
+        let tmp = get_path_keys(1_000_000_000_000);
+        let tmp_path: Vec<TreePath> = tmp.iter().map(|(_, p)| *p).collect();
+        let tmp_right = vec![
+            TreePath::Middle, // (6078833729528464400, Middle)
+            TreePath::Left,   // (2026277909842821466, Left)
+            TreePath::Left,   // (675425969947607155, Left)
+            TreePath::Middle, // (225141989982535718, Middle)
+            TreePath::Middle, // (75047329994178572, Middle)
+            TreePath::Middle, // (25015776664726190, Middle)
+            TreePath::Right,  // (8338592221575396, Right)
+            TreePath::Left,   // (2779530740525131, Left)
+            TreePath::Middle, // (926510246841710, Middle)
+            TreePath::Right,  // (308836748947236, Right)
+            TreePath::Left,   // (102945582982411, Left)
+            TreePath::Middle, // (34315194327470, Middle)
+            TreePath::Middle, // (11438398109156, Middle)
+            TreePath::Left,   // (3812799369718, Left)
+            TreePath::Right,  // (1270933123239, Right)
+            TreePath::Middle, // (423644374412, Middle)
+            TreePath::Middle, // (141214791470, Middle)
+            TreePath::Left,   // (47071597156, Left)
+            TreePath::Middle, // (15690532385, Middle)
+            TreePath::Right,  // (5230177461, Right)
+            TreePath::Middle, // (1743392486, Middle)
+            TreePath::Right,  // (581130828, Right)
+            TreePath::Middle, // (193710275, Middle)
+            TreePath::Middle, // (64570091, Middle)
+            TreePath::Left,   // (21523363, Left)
+            TreePath::Middle, // (7174454, Middle)
+            TreePath::Left,   // (2391484, Left)
+            TreePath::Left,   // (797161, Left)
+            TreePath::Left,   // (265720, Left)
+            TreePath::Left,   // (88573, Left)
+            TreePath::Left,   // (29524, Left)
+            TreePath::Left,   // (9841, Left)
+            TreePath::Left,   // (3280, Left)
+            TreePath::Left,   // (1093, Left)
+            TreePath::Left,   // (364, Left)
+            TreePath::Left,   // (121, Left)
+            TreePath::Left,   // (40, Left)
+            TreePath::Left,   // (13, Left)
+            TreePath::Left,   // (4, Left)
+            TreePath::Left,   // (1, Left)
+            TreePath::Right,  // (0, Right)
+        ];
+        assert_eq!(tmp_path, tmp_right);
+
+        let last_keys = get_path_keys(3u64.pow(40) - 1);
+        let mut last_sum = 0u64;
+        for (i, (key, path)) in last_keys.iter().rev().enumerate() {
+            last_sum += 3u64.pow(i as u32);
+            assert_eq!(*key, last_sum - 1);
+            assert_eq!(*path, TreePath::Right);
+        }
+    }
 }

--- a/zei_api/src/anon_xfr/abar_to_bar.rs
+++ b/zei_api/src/anon_xfr/abar_to_bar.rs
@@ -680,7 +680,7 @@ mod tests {
     #[test]
     fn test_abar_to_bar_conversion() {
         let mut prng = ChaChaRng::from_seed([5u8; 32]);
-        let params = UserParams::abar_to_bar_params(41);
+        let params = UserParams::abar_to_bar_params(40);
 
         let recv = XfrKeyPair::generate(&mut prng);
         let sender = AXfrKeyPair::generate(&mut prng);

--- a/zei_api/src/anon_xfr/abar_to_bar.rs
+++ b/zei_api/src/anon_xfr/abar_to_bar.rs
@@ -663,7 +663,7 @@ mod tests {
     use crate::xfr::asset_record::AssetRecordType::ConfidentialAmount_ConfidentialAssetType;
     use crate::xfr::sig::XfrKeyPair;
     use crate::xfr::structs::AssetType;
-    use accumulators::merkle_tree::{PersistentMerkleTree, Proof};
+    use accumulators::merkle_tree::{PersistentMerkleTree, Proof, TreePath};
     use algebra::bls12_381::BLSScalar;
     use algebra::groups::{Scalar, Zero};
     use crypto::basics::hash::rescue::RescueInstance;
@@ -777,8 +777,8 @@ mod tests {
                     .map(|e| MTNode {
                         siblings1: e.siblings1,
                         siblings2: e.siblings2,
-                        is_left_child: e.is_left_child,
-                        is_right_child: e.is_right_child,
+                        is_left_child: (e.path == TreePath::Left) as u8,
+                        is_right_child: (e.path == TreePath::Right) as u8,
                     })
                     .collect(),
             },

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -176,7 +176,7 @@ impl AMultiXfrPubInputs {
             pk_hash,
             zero,
         ])[0];
-        for path_node in payer.path.nodes.iter().rev() {
+        for path_node in payer.path.nodes.iter() {
             let input = match (path_node.is_left_child, path_node.is_right_child) {
                 (1, 0) => vec![node, path_node.siblings1, path_node.siblings2, zero],
                 (0, 0) => vec![path_node.siblings1, node, path_node.siblings2, zero],
@@ -691,7 +691,7 @@ pub(crate) fn compute_merkle_root(
     let mut node_var =
         cs.rescue_hash(&StateVar::new([uid, commitment, pk_hash_var, zero_var]))[0];
 
-    for path_node in path_vars.nodes.iter().rev() {
+    for path_node in path_vars.nodes.iter() {
         let input_var = sort(
             cs,
             node_var,
@@ -1871,7 +1871,7 @@ pub(crate) mod tests {
                 [0];
 
         // compute the constraints
-        let path = MTPath::new(vec![path_node1, path_node2]);
+        let path = MTPath::new(vec![path_node2, path_node1]);
         let path_vars = add_merkle_path_variables(&mut cs, path);
         let root_var = compute_merkle_root(&mut cs, elem, &path_vars);
 

--- a/zei_api/src/anon_xfr/merkle_tree_test.rs
+++ b/zei_api/src/anon_xfr/merkle_tree_test.rs
@@ -7,9 +7,7 @@ mod tests {
     use crate::anon_xfr::structs::{
         AnonBlindAssetRecord, MTNode, MTPath, OpenAnonBlindAssetRecord,
     };
-    use accumulators::merkle_tree::{
-        generate_path_keys, get_path_from_uid, Path, PersistentMerkleTree, BASE_KEY,
-    };
+    use accumulators::merkle_tree::PersistentMerkleTree;
     use algebra::bls12_381::BLSScalar;
     use algebra::groups::{Scalar, Zero};
     use crypto::basics::hash::rescue::RescueInstance;
@@ -26,269 +24,6 @@ mod tests {
     use storage::store::PrefixedStore;
 
     #[test]
-    pub fn test_generate_path_keys() {
-        let keys = generate_path_keys(vec![Path::Right, Path::Left, Path::Middle]);
-        assert_eq!(
-            keys,
-            vec![
-                "dense_merkle_tree:root:",
-                "dense_merkle_tree:root:r",
-                "dense_merkle_tree:root:rl",
-                "dense_merkle_tree:root:rlm"
-            ]
-        );
-    }
-
-    #[test]
-    fn test_get_path() {
-        let zero_path = get_path_from_uid(0);
-        assert_eq!(zero_path[0], Path::Left);
-        assert_eq!(zero_path[1], Path::Left);
-        assert_eq!(zero_path[2], Path::Left);
-        assert_eq!(zero_path[40], Path::Left);
-
-        let one_path = get_path_from_uid(1);
-        assert_eq!(
-            one_path,
-            vec![
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Middle
-            ]
-        );
-
-        let two_path = get_path_from_uid(2);
-        assert_eq!(
-            two_path,
-            vec![
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Right
-            ]
-        );
-
-        let three_path = get_path_from_uid(3);
-        assert_eq!(
-            three_path,
-            vec![
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Middle,
-                Path::Left
-            ]
-        );
-
-        let four_path = get_path_from_uid(4);
-        assert_eq!(
-            four_path,
-            vec![
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Middle,
-                Path::Middle
-            ]
-        );
-
-        let five_path = get_path_from_uid(5);
-        assert_eq!(
-            five_path,
-            vec![
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Left,
-                Path::Middle,
-                Path::Right
-            ]
-        );
-    }
-
-    #[test]
     fn test_persistent_merkle_tree() {
         let hash = RescueInstance::new();
 
@@ -299,15 +34,7 @@ mod tests {
         let store = PrefixedStore::new("mystore", &mut state);
         let mut mt = PersistentMerkleTree::new(store).unwrap();
 
-        assert_eq!(
-            mt.get_current_root_hash().unwrap(),
-            hash.rescue_hash(&[
-                BLSScalar::zero(),
-                BLSScalar::zero(),
-                BLSScalar::zero(),
-                BLSScalar::zero()
-            ])[0]
-        );
+        assert_eq!(mt.get_current_root_hash().unwrap(), BLSScalar::zero(),);
 
         let abar =
             AnonBlindAssetRecord::from_oabar(&OpenAnonBlindAssetRecord::default());
@@ -325,34 +52,13 @@ mod tests {
             ])[0]
         );
 
-        let mut key = BASE_KEY.to_owned();
-        for _t in 1..42 {
-            key.push('l');
-            let res = mt.get(key.as_bytes());
-            assert!(res.is_ok());
-            assert!(res.unwrap().is_some());
-            // println!("{}       {} {:#?}", t, key, res.unwrap().unwrap());
-        }
+        assert!(mt
+            .add_commitment_hash(hash_abar(mt.entry_count(), &abar))
+            .is_ok());
 
         assert!(mt
             .add_commitment_hash(hash_abar(mt.entry_count(), &abar))
             .is_ok());
-        let key2 = "dense_merkle_tree:root:llllllllllllllllllllllllllllllllllllllllm";
-        let mut res = mt.get(key2.as_bytes());
-        assert!(res.is_ok());
-        assert!(res.unwrap().is_some());
-
-        let key3 = "dense_merkle_tree:root:llllllllllllllllllllllllllllllllllllllllr";
-        res = mt.get(key3.as_bytes());
-        assert!(res.is_ok());
-        assert!(res.unwrap().is_none());
-
-        assert!(mt
-            .add_commitment_hash(hash_abar(mt.entry_count(), &abar))
-            .is_ok());
-        res = mt.get(key3.as_bytes());
-        assert!(res.is_ok());
-        assert!(res.unwrap().is_some());
 
         assert!(mt.generate_proof(0).is_ok());
         assert!(mt.generate_proof(1).is_ok());

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -553,7 +553,7 @@ mod tests {
         let mut state = State::new(cs, false);
         let store = PrefixedStore::new("my_store", &mut state);
 
-        let user_params = UserParams::new(1, 1, Some(41));
+        let user_params = UserParams::new(1, 1, Some(40));
 
         let fee_amount = FEE_CALCULATING_FUNC(1, 1) as u64;
         let output_amount = 10u64;

--- a/zei_api/src/anon_xfr/mod.rs
+++ b/zei_api/src/anon_xfr/mod.rs
@@ -345,7 +345,7 @@ mod tests {
     use std::thread;
 
     use crate::xfr::structs::AssetType;
-    use accumulators::merkle_tree::{PersistentMerkleTree, Proof};
+    use accumulators::merkle_tree::{PersistentMerkleTree, Proof, TreePath};
     use algebra::bls12_381::BLSScalar;
     use algebra::groups::{One, Scalar, ScalarArithmetic, Zero};
 
@@ -374,8 +374,8 @@ mod tests {
                     .map(|e| MTNode {
                         siblings1: e.siblings1,
                         siblings2: e.siblings2,
-                        is_left_child: e.is_left_child,
-                        is_right_child: e.is_right_child,
+                        is_left_child: (e.path == TreePath::Left) as u8,
+                        is_right_child: (e.path == TreePath::Right) as u8,
                     })
                     .collect(),
             },
@@ -579,7 +579,7 @@ mod tests {
             .unwrap();
         let _ = mt.commit();
         let mt_proof = mt.generate_proof(uid).unwrap();
-        assert_eq!(mt.get_current_root_hash().unwrap(), mt_proof.root);
+        assert_eq!(mt.get_root().unwrap(), mt_proof.root);
 
         // output keys
         let keypair_out = AXfrKeyPair::generate(&mut prng);
@@ -658,40 +658,21 @@ mod tests {
                 ])[0]
             };
             let hasher = RescueInstance::new();
-            for i in mt_proof.nodes.iter().rev() {
-                if i.is_left_child == 1u8 {
-                    hash = hasher.rescue_hash(&[
-                        hash,
-                        i.siblings1,
-                        i.siblings2,
-                        BLSScalar::zero(),
-                    ])[0];
-                } else if i.is_right_child == 1u8 {
-                    hash = hasher.rescue_hash(&[
-                        i.siblings1,
-                        i.siblings2,
-                        hash,
-                        BLSScalar::zero(),
-                    ])[0];
-                } else {
-                    hash = hasher.rescue_hash(&[
-                        i.siblings1,
-                        hash,
-                        i.siblings2,
-                        BLSScalar::zero(),
-                    ])[0];
-                }
+            for i in mt_proof.nodes.iter() {
+                let (s1, s2, s3) = match i.path {
+                    TreePath::Left => (hash, i.siblings1, i.siblings2),
+                    TreePath::Middle => (i.siblings1, hash, i.siblings2),
+                    TreePath::Right => (i.siblings1, i.siblings2, hash),
+                };
+                hash = hasher.rescue_hash(&[s1, s2, s3, BLSScalar::zero()])[0];
             }
-            assert_eq!(hash, mt.get_current_root_hash().unwrap());
+            assert_eq!(hash, mt.get_root().unwrap());
         }
         {
             // verifier scope
             let verifier_params = NodeParams::from(user_params);
-            let t = verify_anon_xfr_body(
-                &verifier_params,
-                &body,
-                &mt.get_current_root_hash().unwrap(),
-            );
+            let t =
+                verify_anon_xfr_body(&verifier_params, &body, &mt.get_root().unwrap());
             println!("{:?}", t);
             assert!(t.is_ok());
 


### PR DESCRIPTION
Optimize the accumulator(merkle tree) storage.

### CHANGES
1. Merkle tree `TREE_DEPTH` change from `41` to `40`
2. Merkle proof's node order from `ancestor -> leaf` to `leaf -> ancestor` (avoid reverse)
3. `ProofNode` use `TreePath` replace `is_left_child/is_right_child`

### New functions
1. Add new method: `generate_proof_with_depth` and `get_root_with_depth`. 
    We can update the depth of the circuit tree (for speed up & reduce size) without changing the storage.

### Introduction
use **u64** to include all leaves and ancestors key. Tree key is like:
0 --- (num: 3^0)
1            2           3  --- (num: 3^1)
4 5 6   7 8 9  10 11 12 --- (num: 3^2)
...................................... --- (num: 3^39)
Leaf: ... (num: 3^40)

Old max leaf   is 18446_74407_37095_51616 (2^64 -- sid max)
New max leaf is 12157_66545_90569_28801 (3^40) 

Assuming: 
IF 10000 TPS → 3^40 / (10000 * 60 * 60 * 24 * 365) = 38551704 years, 12 TB/year
IF 100 TPS → 129 GB/year

### Bench: 

Space: 

ancestor key    64 bytes (old) vs 12 bytes (new) --- save 80%. if this DB is only use for merkle_tree, can save more 7% (total 87%).

ancestor key 24 ~ 63 bytes (old)  vs 12 bytes (new) – save (50% ~ 80%)

Speed: 

commit/proof    0.05s  (old) vs 0.05s (new)  --- Equal