### PR TITLE
I have changed a data structure from an Array to a HashMap, to get rid of repited entries

### DIFF
--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use crate::anon_xfr::keys::AXfrPubKey;
 use crate::anon_xfr::structs::{BlindFactor, Commitment, MTNode, MTPath, Nullifier};
 use algebra::bls12_381::BLSScalar;
@@ -18,6 +17,7 @@ use poly_iops::plonk::field_simulation::SimFrVar;
 use poly_iops::plonk::turbo_plonk_cs::ecc::PointVar;
 use poly_iops::plonk::turbo_plonk_cs::rescue::StateVar;
 use poly_iops::plonk::turbo_plonk_cs::{TurboPlonkConstraintSystem, VarIndex};
+use std::collections::HashMap;
 use std::ops::{AddAssign, Shl};
 
 pub type TurboPlonkCS = TurboPlonkConstraintSystem<BLSScalar>;
@@ -767,14 +767,13 @@ fn asset_mixing(
     fee_type: BLSScalar,
     fee_calculating_func: &dyn Fn(u32, u32) -> u32,
 ) {
-
     let mut inputs_type_sum_amounts = HashMap::new();
 
-    for input in inputs.iter(){
+    for input in inputs.iter() {
         let zero_var = cs.zero_var();
-        if  inputs_type_sum_amounts.contains_key(&input.0) {
+        if inputs_type_sum_amounts.contains_key(&input.0) {
             continue;
-        }else {
+        } else {
             let sum_var = inputs.iter().fold(zero_var, |sum, other_input| {
                 let adder = match_select(
                     cs,
@@ -788,14 +787,13 @@ fn asset_mixing(
         }
     }
 
-
     let mut outputs_type_sum_amounts = HashMap::new();
 
-    for output in outputs.iter(){
+    for output in outputs.iter() {
         let zero_var = cs.zero_var();
         if outputs_type_sum_amounts.contains_key(&output.0) {
             continue;
-        }else {
+        } else {
             let sum_var = outputs.iter().fold(zero_var, |sum, other_output| {
                 let adder = match_select(
                     cs,
@@ -808,7 +806,6 @@ fn asset_mixing(
             outputs_type_sum_amounts.insert(output.0, sum_var);
         }
     }
-
 
     // Initialize a constant value `fee_type_val`
     let fee_type_val = cs.new_variable(fee_type);

--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::anon_xfr::keys::AXfrPubKey;
 use crate::anon_xfr::structs::{BlindFactor, Commitment, MTNode, MTPath, Nullifier};
 use algebra::bls12_381::BLSScalar;
@@ -751,7 +752,6 @@ pub(crate) fn nullify(
 ///
 /// The circuit:
 /// 1. Compute [sum_in_1, ..., sum_in_n] from inputs, where `sum_in_i = \sum_{j : type_in_j == type_in_i} v_in_j`
-///    Note: If there are two inputs with the same asset type, then their `sum_in_i` would be the same.
 /// 2. Similarly, compute [sum_out_1, ..., sum_out_m] from outputs.
 /// 3. Enumerate pair `(i \in [n], j \in [m])`, check that:
 ///         `(type_in_i == fee_type) \lor (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j)`
@@ -767,11 +767,14 @@ fn asset_mixing(
     fee_type: BLSScalar,
     fee_calculating_func: &dyn Fn(u32, u32) -> u32,
 ) {
-    // Compute the `sum_in_i`
-    let inputs_type_sum_amounts: Vec<(VarIndex, VarIndex)> = inputs
-        .iter()
-        .map(|input| {
-            let zero_var = cs.zero_var();
+
+    let mut inputs_type_sum_amounts = HashMap::new();
+
+    for input in inputs.iter(){
+        let zero_var = cs.zero_var();
+        if  inputs_type_sum_amounts.contains_key(&input.0) {
+            continue;
+        }else {
             let sum_var = inputs.iter().fold(zero_var, |sum, other_input| {
                 let adder = match_select(
                     cs,
@@ -781,15 +784,18 @@ fn asset_mixing(
                 ); // amount
                 cs.add(sum, adder)
             });
-            (input.0, sum_var)
-        })
-        .collect();
+            inputs_type_sum_amounts.insert(input.0, sum_var);
+        }
+    }
 
-    // Compute the `sum_out_i`
-    let outputs_type_sum_amounts: Vec<(VarIndex, VarIndex)> = outputs
-        .iter()
-        .map(|output| {
-            let zero_var = cs.zero_var();
+
+    let mut outputs_type_sum_amounts = HashMap::new();
+
+    for output in outputs.iter(){
+        let zero_var = cs.zero_var();
+        if outputs_type_sum_amounts.contains_key(&output.0) {
+            continue;
+        }else {
             let sum_var = outputs.iter().fold(zero_var, |sum, other_output| {
                 let adder = match_select(
                     cs,
@@ -799,9 +805,10 @@ fn asset_mixing(
                 ); // amount
                 cs.add(sum, adder)
             });
-            (output.0, sum_var)
-        })
-        .collect();
+            outputs_type_sum_amounts.insert(output.0, sum_var);
+        }
+    }
+
 
     // Initialize a constant value `fee_type_val`
     let fee_type_val = cs.new_variable(fee_type);
@@ -819,7 +826,7 @@ fn asset_mixing(
     // and also check that the amount is matching
     // and also check that every input type appears in the set of output types (except if the fee has used up)
     let mut flag_no_fee_type = cs.one_var();
-    for (input_type, input_sum) in inputs_type_sum_amounts {
+    for (&input_type, &input_sum) in inputs_type_sum_amounts.iter() {
         let (is_fee_type, is_not_fee_type) =
             cs.is_equal_or_not_equal(input_type, fee_type_val);
         flag_no_fee_type = cs.mul(flag_no_fee_type, is_not_fee_type);
@@ -829,7 +836,7 @@ fn asset_mixing(
         // If there is at least one output that is of the same type as the input, then `flag_no_matching_output = 0`
         // Otherwise, `flag_no_matching_output = 1`.
         let mut flag_no_matching_output = cs.one_var();
-        for &(output_type, output_sum) in &outputs_type_sum_amounts {
+        for (&output_type, &output_sum) in outputs_type_sum_amounts.iter() {
             let (type_matched, type_not_matched) =
                 cs.is_equal_or_not_equal(input_type, output_type);
             flag_no_matching_output = cs.mul(flag_no_matching_output, type_not_matched);


### PR DESCRIPTION
This is subtil modification motivated by the following note in the comments about "asset_mixing"

/// Enforce asset_mixing_with_fees constraints:
/// Inputs = [(type_in_1, v_in_1), ..., (type_in_n, v_in_n)], `values {v_in_i}` are guaranteed to be positive.
/// Outputs = [(type_out_1, v_out_1), ..., (type_out_m, v_out_m)], `values {v_out_j}` are guaranteed to be positive.
/// Fee parameters = `fee_type` and `fee_calculating func`
///
/// Goal:
/// - Prove that for every asset type except `fee_type`, the corresponding inputs sum equals the corresponding outputs sum.
/// - Prove that for every asset type that equals `fee_type`, the inputs sum = the outputs sum + fee
/// - Prove that at least one input is of type `fee_type`
///
/// The circuit:
/// 1. Compute [sum_in_1, ..., sum_in_n] from inputs, where `sum_in_i = \sum_{j : type_in_j == type_in_i} v_in_j`

///    **Note: If there are two inputs with the same asset type, then their `sum_in_i` would be the same.**  <======This one

/// 2. Similarly, compute [sum_out_1, ..., sum_out_m] from outputs.
/// 3. Enumerate pair `(i \in [n], j \in [m])`, check that:
///         `(type_in_i == fee_type) \lor (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j)`
///         `(type_in_i != fee_type) \lor (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j + fee)`
/// 4. Ensure that except the fee type, all the input type has also shown up as an output type.
/// 5. Ensure that for the fee type, if there is no output fee type, then the input must provide the exact fee.
///
/// This function assumes that the inputs and outputs have been correctly bounded.

So insted of having a repited entries I have put the "asset type" as a key in hashmap and the corresponding sumation as a value.

Please check the code and I give me your thoghts and comments.