### PR TITLE
Modification in asset_mixing function from circuit.rs was made to avoid repeated entries

### DIFF
--- a/zei_api/src/anon_xfr/circuits.rs
+++ b/zei_api/src/anon_xfr/circuits.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use crate::anon_xfr::keys::AXfrPubKey;
 use crate::anon_xfr::structs::{BlindFactor, Commitment, MTNode, MTPath, Nullifier};
 use algebra::bls12_381::BLSScalar;
@@ -18,6 +17,7 @@ use poly_iops::plonk::field_simulation::SimFrVar;
 use poly_iops::plonk::turbo_plonk_cs::ecc::PointVar;
 use poly_iops::plonk::turbo_plonk_cs::rescue::StateVar;
 use poly_iops::plonk::turbo_plonk_cs::{TurboPlonkConstraintSystem, VarIndex};
+use std::collections::HashSet;
 use std::ops::{AddAssign, Shl};
 
 pub type TurboPlonkCS = TurboPlonkConstraintSystem<BLSScalar>;
@@ -767,8 +767,6 @@ fn asset_mixing(
     fee_type: BLSScalar,
     fee_calculating_func: &dyn Fn(u32, u32) -> u32,
 ) {
-
-
     let mut input_checked = HashSet::new();
     // Compute the `sum_in_i`
     let inputs_type_sum_amounts: Vec<(VarIndex, VarIndex)> = inputs
@@ -814,8 +812,6 @@ fn asset_mixing(
             None
         })
         .collect();
-
-    
 
     // Initialize a constant value `fee_type_val`
     let fee_type_val = cs.new_variable(fee_type);


### PR DESCRIPTION

This is subtle modification motivated by the following note in the comments about "asset_mixing"

/// Enforce asset_mixing_with_fees constraints:
/// Inputs = [(type_in_1, v_in_1), ..., (type_in_n, v_in_n)], values {v_in_i} are guaranteed to be positive.
/// Outputs = [(type_out_1, v_out_1), ..., (type_out_m, v_out_m)], values {v_out_j} are guaranteed to be positive.
/// Fee parameters = fee_type and fee_calculating func
///
/// Goal:
/// - Prove that for every asset type except fee_type, the corresponding inputs sum equals the corresponding outputs sum.
/// - Prove that for every asset type that equals fee_type, the inputs sum = the outputs sum + fee
/// - Prove that at least one input is of type fee_type
///
/// The circuit:
/// 1. Compute [sum_in_1, ..., sum_in_n] from inputs, where sum_in_i = \sum_{j : type_in_j == type_in_i} v_in_j

/// Note: If there are two inputs with the same asset type, then their sum_in_i would be the same. <======This one

/// 2. Similarly, compute [sum_out_1, ..., sum_out_m] from outputs.
/// 3. Enumerate pair (i \in [n], j \in [m]), check that:
/// (type_in_i == fee_type) \lor (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j)
/// (type_in_i != fee_type) \lor (type_in_i != type_out_j) \lor (sum_in_i == sum_out_j + fee)
/// 4. Ensure that except the fee type, all the input type has also shown up as an output type.
/// 5. Ensure that for the fee type, if there is no output fee type, then the input must provide the exact fee.
///
/// This function assumes that the inputs and outputs have been correctly bounded.

So instead of having a repited entries it is checked if the "asset type" exists in a hashset, and get rid of repited entries

Please check the code and I give me your thoghts and comments.
