### PR TITLE
Add hardcoded verifier params to unit tests

### DIFF
--- a/zei_api/src/anon_xfr/anon_fee.rs
+++ b/zei_api/src/anon_xfr/anon_fee.rs
@@ -420,7 +420,7 @@ mod tests {
 
         {
             // verifier scope
-            let verifier_params = NodeParams::from(user_params);
+            let verifier_params = NodeParams::anon_fee_params().unwrap();
             assert!(verify_anon_fee_body(
                 &verifier_params,
                 &body,

--- a/zei_api/src/setup.rs
+++ b/zei_api/src/setup.rs
@@ -256,11 +256,7 @@ impl NodeParams {
                         verifier_params: special.verifier_params,
                     })
                 }
-                _ => Err(SimpleError::new(
-                    d!(ZeiError::MissingVerifierParamsError),
-                    None,
-                )
-                .into()),
+                _ => Self::create(n_payers, n_payees, None),
             }
         }
     }


### PR DESCRIPTION
In zei, the verifier parameters are saved in a file to be read quickly instead of generating during runtime.
- anon-transfer: https://github.com/FindoraNetwork/zei/blob/develop/zei_api/src/anon_xfr/mod.rs#L683
- bar-to-abar: https://github.com/FindoraNetwork/zei/blob/develop/zei_api/src/anon_xfr/bar_to_abar.rs#L340
- abar-to-bar: https://github.com/FindoraNetwork/zei/blob/develop/zei_api/src/anon_xfr/abar_to_bar.rs#L729
- anon-fee: this PR.

There should be fail if the circuit for the above is changed without updating the files.