### PR TITLE
Bump aes to 0.8.1

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -10,6 +10,8 @@ name = 'zei_crypto'
 crate-type = ['rlib']
 
 [dependencies]
+aes = '0.8.1'
+ctr = '0.9.1'
 digest = '0.9'
 ed25519-dalek = '1.0.0'
 itertools = '0.10.3'
@@ -23,10 +25,6 @@ ruc = '1.0'
 
 [dependencies.zei-algebra]
 path = '../algebra'
-
-[dependencies.aes]
-version = '0.7.5'
-features = ['ctr']
 
 [dependencies.bulletproofs]
 package = 'bulletproofs'

--- a/crypto/src/basics/hybrid_encryption.rs
+++ b/crypto/src/basics/hybrid_encryption.rs
@@ -1,19 +1,17 @@
 use aes::{
-    cipher::{generic_array::GenericArray, NewCipher, StreamCipher},
-    Aes256Ctr,
+    cipher::{generic_array::GenericArray, KeyIvInit, StreamCipher},
+    Aes256,
 };
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use ed25519_dalek::{ExpandedSecretKey, PublicKey, SecretKey};
-use rand_core::{CryptoRng, RngCore};
-use ruc::*;
 use serde::Serializer;
 use sha2::Digest;
 use wasm_bindgen::prelude::*;
 use zei_algebra::errors::ZeiError;
 use zei_algebra::prelude::*;
-use zei_algebra::ristretto::RistrettoScalar as Scalar;
-use zei_algebra::serialization::ZeiFromToBytes;
-use zei_algebra::traits::Scalar as _;
+use zei_algebra::ristretto::RistrettoScalar;
+
+type Aes256Ctr = ctr::Ctr64BE<Aes256>;
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -215,12 +213,12 @@ where
     symmetric_key_from_x25519_public_key(prng, &x_public_key)
 }
 
-fn sec_key_as_scalar(sk: &SecretKey) -> Scalar {
+fn sec_key_as_scalar(sk: &SecretKey) -> RistrettoScalar {
     let expanded: ExpandedSecretKey = sk.into();
     //expanded.key is not public, I need to extract it via serialization
     let mut key_bytes = [0u8; 32];
     key_bytes.copy_from_slice(&expanded.to_bytes()[0..32]); //1st 32 bytes are key
-    Scalar::from_bytes(&key_bytes).unwrap() // safe unwrap
+    RistrettoScalar::from_bytes(&key_bytes).unwrap() // safe unwrap
 }
 
 fn symmetric_key_from_x25519_secret_key(


### PR DESCRIPTION
Since RustCrypto has refactored aes and separated the counter mode implementation into a separate crate, this PR bumps its version and closes #46.