### PR TITLE
Documentation and cleanup of ElGamal

### DIFF
--- a/api/src/anon_creds.rs
+++ b/api/src/anon_creds.rs
@@ -430,5 +430,5 @@ pub fn ac_confidential_verify(
 pub fn ac_confidential_gen_encryption_keys<R: CryptoRng + RngCore>(
     prng: &mut R,
 ) -> (AttributeDecKey, AttributeEncKey) {
-    elgamal_key_gen::<_, G1>(prng, &G1::get_base())
+    elgamal_key_gen::<_, G1>(prng)
 }

--- a/api/src/serialization.rs
+++ b/api/src/serialization.rs
@@ -67,45 +67,6 @@ impl ZeiFromToBytes for XfrSignature {
 
 serialize_deserialize!(XfrSignature);
 
-/*
-// XXX keep this for future reference
-// use with #[serde(with = "serialization::option_bytes")]
-pub mod option_bytes {
-  use crate::serialization::ZeiFromToBytes;
-  use serde::{self, Deserialize, Deserializer, Serializer};
-
-  pub fn serialize<S, T>(object: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer,
-          T: ZeiFromToBytes
-  {
-    if object.is_none() {
-      serializer.serialize_none()
-    } else {
-      let bytes = object.as_ref().unwrap().zei_to_bytes();
-      //let encoded = hex::encode(&bytes[..]);
-      if serializer.is_human_readable() {
-        serializer.serialize_str(&b64enc(bytes.as_slice()))
-      } else {
-        serializer.serialize_bytes(bytes.as_slice())
-      }
-    }
-  }
-
-  pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
-    where D: Deserializer<'de>,
-          T: ZeiFromToBytes
-  {
-    let vec: Option<Vec<u8>> = Option::deserialize(deserializer)?;
-
-    if let Some(value) = vec {
-      Ok(Some(T::zei_from_bytes(value.as_slice())))
-    } else {
-      Ok(None)
-    }
-  }
-}
-*/
-
 #[cfg(test)]
 mod test {
     use crate::anon_xfr::keys::{AXfrKeyPair, AXfrPubKey};
@@ -123,7 +84,6 @@ mod test {
     use serde::{de::Deserialize, ser::Serialize};
     use std::convert::TryFrom;
     use zei_algebra::ristretto::RistrettoPoint;
-    use zei_crypto::basics::ristretto_pedersen_comm::RistrettoPedersenCommitment;
     use zei_crypto::basics::{
         elgamal::elgamal_key_gen,
         hybrid_encryption::{XPublicKey, XSecretKey},
@@ -316,8 +276,7 @@ mod test {
     #[test]
     fn serialize_and_deserialize_elgamal() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        let pc_gens = RistrettoPedersenCommitment::default();
-        let (_sk, xfr_pub_key) = elgamal_key_gen::<_, RistrettoPoint>(&mut prng, &pc_gens.B);
+        let (_sk, xfr_pub_key) = elgamal_key_gen::<_, RistrettoPoint>(&mut prng);
         let serialized = if let Ok(res) = serde_json::to_string(&xfr_pub_key) {
             res
         } else {

--- a/api/src/xfr/structs.rs
+++ b/api/src/xfr/structs.rs
@@ -14,9 +14,8 @@ use bulletproofs::RangeProof;
 use digest::Digest;
 use sha2::Sha512;
 use zei_algebra::{
-    bls12_381::BLSG1,
     prelude::*,
-    ristretto::{CompressedEdwardsY, CompressedRistretto, RistrettoPoint, RistrettoScalar},
+    ristretto::{CompressedEdwardsY, CompressedRistretto, RistrettoScalar},
 };
 use zei_crypto::basics::ristretto_pedersen_comm::RistrettoPedersenCommitment;
 use zei_crypto::{
@@ -313,9 +312,8 @@ pub struct AssetTracerKeyPair {
 impl AssetTracerKeyPair {
     /// Generates a new keypair for asset tracing
     pub fn generate<R: CryptoRng + RngCore>(prng: &mut R) -> Self {
-        let (record_data_dec_key, record_data_enc_key) =
-            elgamal_key_gen(prng, &RistrettoPoint::get_base());
-        let (attrs_dec_key, attrs_enc_key) = elgamal_key_gen(prng, &BLSG1::get_base());
+        let (record_data_dec_key, record_data_enc_key) = elgamal_key_gen(prng);
+        let (attrs_dec_key, attrs_enc_key) = elgamal_key_gen(prng);
         let lock_info_dec_key = XSecretKey::new(prng);
         let lock_info_enc_key = XPublicKey::from(&lock_info_dec_key);
         AssetTracerKeyPair {

--- a/api/src/xfr/tests.rs
+++ b/api/src/xfr/tests.rs
@@ -840,9 +840,9 @@ mod asset_tracing {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
         let pc_gens = RistrettoPedersenCommitment::default();
 
-        let (_sk, pk) = elgamal_key_gen::<_, RistrettoPoint>(&mut prng, &pc_gens.B);
+        let (_sk, pk) = elgamal_key_gen::<_, RistrettoPoint>(&mut prng);
 
-        let ctext = elgamal_encrypt(&pc_gens.B, &m, &r, &pk);
+        let ctext = elgamal_encrypt(&m, &r, &pk);
         let commitment = pc_gens.commit(m, r);
 
         let mut prover_transcript = Transcript::new(b"test");

--- a/crypto/src/basics/elgamal.rs
+++ b/crypto/src/basics/elgamal.rs
@@ -5,7 +5,7 @@ use zei_algebra::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ElGamalEncKey<G>(pub G); //PK = sk*G
+pub struct ElGamalEncKey<G>(pub G); // pk = sk * G
 
 impl<G: Clone> ElGamalEncKey<G> {
     pub fn get_point(&self) -> G {
@@ -17,21 +17,12 @@ impl<G: Clone> ElGamalEncKey<G> {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ElGamalDecKey<S>(pub(crate) S); //sk
-
-pub fn elgamal_key_gen<R: CryptoRng + RngCore, G: Group>(
-    prng: &mut R,
-    base: &G,
-) -> (ElGamalDecKey<G::ScalarType>, ElGamalEncKey<G>) {
-    let secret_key = ElGamalDecKey(G::ScalarType::random(prng));
-    let public_key = ElGamalEncKey(base.mul(&secret_key.0));
-    (secret_key, public_key)
-}
+pub struct ElGamalDecKey<S>(pub(crate) S); // sk
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ElGamalCiphertext<G> {
-    pub e1: G, //r*G
-    pub e2: G, //m*G + r*PK
+    pub e1: G, // r * G
+    pub e2: G, // m * G + r * pk
 }
 
 impl Hash for ElGamalEncKey<RistrettoPoint> {
@@ -56,26 +47,36 @@ impl ZeiFromToBytes for ElGamalCiphertext<RistrettoPoint> {
     }
 }
 
-/// I return an ElGamal ciphertext pair as (r*G, m*g + r*PK), where G is a curve base point
+/// Return an ElGamal key pair as `(sk, pk = sk * G)`
+pub fn elgamal_key_gen<R: CryptoRng + RngCore, G: Group>(
+    prng: &mut R,
+) -> (ElGamalDecKey<G::ScalarType>, ElGamalEncKey<G>) {
+    let base = G::get_base();
+    let secret_key = ElGamalDecKey(G::ScalarType::random(prng));
+    let public_key = ElGamalEncKey(base.mul(&secret_key.0));
+    (secret_key, public_key)
+}
+
+/// Return an ElGamal ciphertext pair as `(r * G, m * G + r * pk)`, where `G` is a base point on the curve
 pub fn elgamal_encrypt<G: Group>(
-    base: &G,
     m: &G::ScalarType,
     r: &G::ScalarType,
     pub_key: &ElGamalEncKey<G>,
 ) -> ElGamalCiphertext<G> {
+    let base = G::get_base();
     let e1 = base.mul(r);
     let e2 = base.mul(m).add(&(pub_key.0).mul(r));
 
     ElGamalCiphertext::<G> { e1, e2 }
 }
 
-/// I verify that ctext encrypts m (ctext.e2 - ctext.e1 * sk = m* G)
+/// Verify that the ElGamal ciphertext encrypts m by checking `ctext.e2 - ctext.e1 * sk = m * G`
 pub fn elgamal_verify<G: Group>(
-    base: &G,
     m: &G::ScalarType,
     ctext: &ElGamalCiphertext<G>,
     sec_key: &ElGamalDecKey<G::ScalarType>,
 ) -> Result<()> {
+    let base = G::get_base();
     if base.mul(m).add(&ctext.e1.mul(&sec_key.0)) == ctext.e2 {
         Ok(())
     } else {
@@ -83,7 +84,7 @@ pub fn elgamal_verify<G: Group>(
     }
 }
 
-/// ElGamal decryption: Return group element
+/// Perform a partial decryption for the ElGamal ciphertext that returns `m * G`
 pub fn elgamal_partial_decrypt<G: Group>(
     ctext: &ElGamalCiphertext<G>,
     sec_key: &ElGamalDecKey<G::ScalarType>,
@@ -105,17 +106,16 @@ mod elgamal_test {
 
     fn verification<G: Group>() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        let base = G::get_base();
 
-        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng, &base);
+        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng);
 
         let m = G::ScalarType::from(100u32);
         let r = G::ScalarType::random(&mut prng);
-        let ctext = super::elgamal_encrypt::<G>(&base, &m, &r, &public_key);
-        pnk!(super::elgamal_verify::<G>(&base, &m, &ctext, &secret_key));
+        let ctext = super::elgamal_encrypt::<G>(&m, &r, &public_key);
+        pnk!(super::elgamal_verify::<G>(&m, &ctext, &secret_key));
 
         let wrong_m = G::ScalarType::from(99u32);
-        let err = super::elgamal_verify(&base, &wrong_m, &ctext, &secret_key)
+        let err = super::elgamal_verify(&wrong_m, &ctext, &secret_key)
             .err()
             .unwrap();
         msg_eq!(ZeiError::ElGamalVerificationError, err);
@@ -123,28 +123,24 @@ mod elgamal_test {
 
     fn decryption<G: Group>() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        let base = G::get_base();
-
-        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng, &base);
+        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng);
 
         let mu32 = 100u32;
         let m = G::ScalarType::from(mu32);
         let r = G::ScalarType::random(&mut prng);
-        let ctext = super::elgamal_encrypt(&base, &m, &r, &public_key);
-        pnk!(super::elgamal_verify(&base, &m, &ctext, &secret_key));
+        let ctext = super::elgamal_encrypt(&m, &r, &public_key);
+        pnk!(super::elgamal_verify(&m, &ctext, &secret_key));
 
         let m = G::ScalarType::from(u64::MAX);
-        let ctext = super::elgamal_encrypt(&base, &m, &r, &public_key);
-        pnk!(super::elgamal_verify(&base, &m, &ctext, &secret_key));
+        let ctext = super::elgamal_encrypt(&m, &r, &public_key);
+        pnk!(super::elgamal_verify(&m, &ctext, &secret_key));
     }
 
     fn serialize_to_json<G: Group>() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        let base = G::get_base();
+        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng);
 
-        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng, &base);
-
-        //keys serialization
+        // key serialization
         let json_str = serde_json::to_string(&secret_key).unwrap();
         let sk_de: ElGamalDecKey<G::ScalarType> = serde_json::from_str(&json_str).unwrap();
         assert_eq!(secret_key, sk_de);
@@ -153,11 +149,11 @@ mod elgamal_test {
         let pk_de: ElGamalEncKey<G> = serde_json::from_str(&json_str).unwrap();
         assert_eq!(public_key, pk_de);
 
-        //ciphertext serialization
+        // ciphertext serialization
         let m = G::ScalarType::from(100u32);
         let r = G::ScalarType::random(&mut prng);
 
-        let ctext = super::elgamal_encrypt(&base, &m, &r, &public_key);
+        let ctext = super::elgamal_encrypt(&m, &r, &public_key);
         let json_str = serde_json::to_string(&ctext).unwrap();
         let ctext_de: ElGamalCiphertext<G> = serde_json::from_str(&json_str).unwrap();
 
@@ -166,11 +162,9 @@ mod elgamal_test {
 
     fn serialize_to_message_pack<G: Group>() {
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        let base = G::get_base();
+        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng);
 
-        let (secret_key, public_key) = super::elgamal_key_gen::<_, G>(&mut prng, &base);
-
-        //keys serialization
+        // key serialization
         let mut vec = vec![];
         secret_key
             .serialize(&mut rmp_serde::Serializer::new(&mut vec))
@@ -179,7 +173,7 @@ mod elgamal_test {
         let sk_de: ElGamalDecKey<G::ScalarType> = Deserialize::deserialize(&mut de).unwrap();
         assert_eq!(secret_key, sk_de);
 
-        //public key serialization
+        // public key serialization
         let mut vec = vec![];
         public_key
             .serialize(&mut rmp_serde::Serializer::new(&mut vec))
@@ -188,11 +182,11 @@ mod elgamal_test {
         let pk_de: ElGamalEncKey<G> = Deserialize::deserialize(&mut de).unwrap();
         assert_eq!(public_key, pk_de);
 
-        //ciphertext serialization
+        // ciphertext serialization
         let m = G::ScalarType::from(100u32);
         let r = G::ScalarType::random(&mut prng);
 
-        let ctext = super::elgamal_encrypt(&base, &m, &r, &public_key);
+        let ctext = super::elgamal_encrypt(&m, &r, &public_key);
 
         let mut vec = vec![];
         ctext


### PR DESCRIPTION
The documentation of ElGamal is done in a separate Overleaf document.

The code of ElGamal has been cleaned up. Previously, most of the ElGamal algorithms require providing a base element. This requirement is now removed by pulling the base element directly from the group implementation.