### PR TITLE
Documentation and cleanup of the matrix Sigma protocol 

### DIFF
--- a/crypto/src/anon_creds.rs
+++ b/crypto/src/anon_creds.rs
@@ -78,7 +78,7 @@ in the credentials by
          e(sigma2', c * G2) = e(G1,G2) * r * c * u * (x + \sum attr_i * y_i + t + sk * x)
 */
 
-use crate::basics::sigma::{SigmaTranscript, SigmaTranscriptPairing};
+use crate::{basics::matrix_sigma::SigmaTranscript, conf_cred_reveal::CACTranscript};
 use merlin::Transcript;
 use zei_algebra::{prelude::*, traits::Pairing};
 

--- a/crypto/src/basics/mod.rs
+++ b/crypto/src/basics/mod.rs
@@ -1,8 +1,8 @@
 pub mod chaum_pedersen;
 pub mod elgamal;
 pub mod hybrid_encryption;
+pub mod matrix_sigma;
 pub mod pedersen_elgamal;
 pub mod rescue;
 pub mod ristretto_pedersen_comm;
 pub mod schnorr;
-pub mod sigma;

--- a/crypto/src/basics/pedersen_elgamal.rs
+++ b/crypto/src/basics/pedersen_elgamal.rs
@@ -1,6 +1,6 @@
 use crate::basics::elgamal::{ElGamalCiphertext, ElGamalEncKey};
+use crate::basics::matrix_sigma::{sigma_prove, sigma_verify_scalars, SigmaProof, SigmaTranscript};
 use crate::basics::ristretto_pedersen_comm::RistrettoPedersenCommitment;
-use crate::basics::sigma::{sigma_prove, sigma_verify_scalars, SigmaProof, SigmaTranscript};
 use curve25519_dalek::traits::{Identity, MultiscalarMul};
 use merlin::Transcript;
 use zei_algebra::prelude::*;


### PR DESCRIPTION
The documentation of the matrix Sigma protocol is done in a separate Overleaf document.

The code of the matrix Sigma protocol has been cleaned up. This enables us to work on Chaum-Pedersen as well as related primitives.