### PR TITLE
Documentation and cleanup of Schnorr

### DIFF
--- a/api/src/anon_xfr/abar_to_bar.rs
+++ b/api/src/anon_xfr/abar_to_bar.rs
@@ -208,7 +208,7 @@ pub fn gen_abar_to_bar_note<R: CryptoRng + RngCore>(
     let msg = bincode::serialize(&body)
         .c(d!(ZeiError::SerializationError))
         .c(d!())?;
-    let signature = randomized_keypair.sign(&msg);
+    let signature = randomized_keypair.sign(prng, &msg);
     let note = AbarToBarNote { body, signature };
     Ok(note)
 }

--- a/api/src/anon_xfr/keys.rs
+++ b/api/src/anon_xfr/keys.rs
@@ -46,8 +46,8 @@ impl AXfrKeyPair {
         self.0.get_secret_scalar()
     }
 
-    pub fn sign(&self, msg: &[u8]) -> AXfrSignature {
-        AXfrSignature(self.0.sign(msg))
+    pub fn sign<R: CryptoRng + RngCore>(&self, prng: &mut R, msg: &[u8]) -> AXfrSignature {
+        AXfrSignature(self.0.sign(prng, msg))
     }
 }
 

--- a/api/src/anon_xfr/mod.rs
+++ b/api/src/anon_xfr/mod.rs
@@ -478,7 +478,7 @@ mod tests {
             let verifier_params = NodeParams::from(user_params);
             assert!(verify_anon_xfr_body(&verifier_params, &body, &merkle_root).is_ok());
 
-            let note = AXfrNote::generate_note_from_body(body, key_pairs).unwrap();
+            let note = AXfrNote::generate_note_from_body(&mut prng, body, key_pairs).unwrap();
             assert!(note.verify().is_ok())
         }
     }
@@ -643,7 +643,7 @@ mod tests {
             let vk2 = NodeParams::load(1, 1).unwrap();
             assert!(verify_anon_xfr_body(&vk2, &body, &mt.get_root().unwrap()).is_ok());
 
-            let note = AXfrNote::generate_note_from_body(body, key_pairs).unwrap();
+            let note = AXfrNote::generate_note_from_body(&mut prng, body, key_pairs).unwrap();
             assert!(note.verify().is_ok())
         }
     }

--- a/api/src/anon_xfr/structs.rs
+++ b/api/src/anon_xfr/structs.rs
@@ -42,14 +42,18 @@ pub struct AXfrNote {
 }
 
 impl AXfrNote {
-    pub fn generate_note_from_body(body: AXfrBody, keypairs: Vec<AXfrKeyPair>) -> Result<AXfrNote> {
+    pub fn generate_note_from_body<R: CryptoRng + RngCore>(
+        prng: &mut R,
+        body: AXfrBody,
+        keypairs: Vec<AXfrKeyPair>,
+    ) -> Result<AXfrNote> {
         let mut signatures: Vec<AXfrSignature> = Vec::new();
         let msg: Vec<u8> = bincode::serialize(&body)
             .map_err(|_| ZeiError::SerializationError)
             .c(d!())?;
 
         for keypair in keypairs {
-            signatures.push(keypair.sign(msg.as_slice()))
+            signatures.push(keypair.sign(prng, msg.as_slice()))
         }
 
         Ok(AXfrNote { body, signatures })


### PR DESCRIPTION
The documentation of Schnorr is done in a separate Overleaf document. This PR cleans up the code for Schnorr. Most importantly, it changes the deterministic Schnorr signature to a randomized one, as the security would be easier to argue, and it really is not a big issue that the signing algorithms are randomized. 