### PR TITLE
Update merkle tree version

### DIFF
--- a/accumulators/src/lib.rs
+++ b/accumulators/src/lib.rs
@@ -37,6 +37,7 @@ mod tests {
         let mut state = State::new(cs, false);
         let store = PrefixedStore::new("my_store", &mut state);
         let mut mt = PersistentMerkleTree::new(store).unwrap();
+        assert_eq!(0, mt.version());
 
         let start = Instant::now();
         for _ in 0..10 {
@@ -47,9 +48,14 @@ mod tests {
         }
         let end = start.elapsed();
         println!("Time: {:?} microseconds", end.as_micros());
+        let v1 = mt.commit().unwrap();
+        assert_eq!(v1, mt.version());
+        assert_eq!(1, v1);
 
         let sid_x = mt.add_commitment_hash(BLSScalar::one()).unwrap();
         let proofx = mt.generate_proof_with_depth(sid_x, 10).unwrap();
+        let _v2 = mt.commit().unwrap();
+        assert_eq!(2, mt.version());
         assert!(verify(BLSScalar::one(), &proofx));
         let proof4 = mt.generate_proof_with_depth(sid_x, 14).unwrap();
         assert!(verify(BLSScalar::one(), &proof4));

--- a/accumulators/src/lib.rs
+++ b/accumulators/src/lib.rs
@@ -19,7 +19,7 @@ pub mod merkle_tree;
 
 #[cfg(test)]
 mod tests {
-    use crate::merkle_tree::{verify, PersistentMerkleTree};
+    use crate::merkle_tree::{verify, PersistentMerkleTree, TREE_DEPTH};
     use parking_lot::RwLock;
     use std::sync::Arc;
     use std::thread;
@@ -33,7 +33,12 @@ mod tests {
     fn test_merkle_tree() {
         let path = thread::current().name().unwrap().to_owned();
         let fdb = TempRocksDB::open(path).expect("failed to open db");
-        let cs = Arc::new(RwLock::new(ChainState::new(fdb, "test_db".to_string(), 0)));
+        let ver_window = 100;
+        let cs = Arc::new(RwLock::new(ChainState::new(
+            fdb,
+            "test_db".to_string(),
+            ver_window,
+        )));
         let mut state = State::new(cs, false);
         let store = PrefixedStore::new("my_store", &mut state);
         let mut mt = PersistentMerkleTree::new(store).unwrap();
@@ -49,17 +54,26 @@ mod tests {
         let end = start.elapsed();
         println!("Time: {:?} microseconds", end.as_micros());
         let v1 = mt.commit().unwrap();
+        let root1 = mt.get_root().unwrap();
         assert_eq!(v1, mt.version());
         assert_eq!(1, v1);
 
         let sid_x = mt.add_commitment_hash(BLSScalar::one()).unwrap();
         let proofx = mt.generate_proof_with_depth(sid_x, 10).unwrap();
-        let _v2 = mt.commit().unwrap();
+        let v2 = mt.commit().unwrap();
         assert_eq!(2, mt.version());
+        let root2 = mt.get_root_with_depth(10).unwrap();
+
         assert!(verify(BLSScalar::one(), &proofx));
         let proof4 = mt.generate_proof_with_depth(sid_x, 14).unwrap();
         assert!(verify(BLSScalar::one(), &proof4));
         assert!(mt.generate_proof_with_depth(sid_x, 21).is_err());
         assert!(mt.generate_proof_with_depth(sid_x, 2).is_err());
+
+        assert_eq!(
+            mt.get_root_with_depth_and_version(TREE_DEPTH, v1).unwrap(),
+            root1
+        );
+        assert_eq!(mt.get_root_with_depth_and_version(10, v2).unwrap(), root2);
     }
 }

--- a/accumulators/src/merkle_tree.rs
+++ b/accumulators/src/merkle_tree.rs
@@ -216,7 +216,25 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
 
         match self.store.get(&store_key)? {
             Some(hash) => BLSScalar::zei_from_bytes(hash.as_slice()),
-            None => Err(eg!("root hash key not found")),
+            None => Err(eg!("root hash key not found at this depth")),
+        }
+    }
+
+    /// get tree root by depth and version.
+    pub fn get_root_with_depth_and_version(&self, depth: usize, version: u64) -> Result<BLSScalar> {
+        if version == 0 {
+            return Ok(BLSScalar::zero());
+        }
+
+        let mut pos = 0u64;
+        for i in 0..(TREE_DEPTH - depth) {
+            pos += 3u64.pow(i as u32);
+        }
+        let mut store_key = KEY_PAD.to_vec();
+        store_key.extend(pos.to_be_bytes());
+        match self.store.get_v(&store_key, version)? {
+            Some(hash) => BLSScalar::zei_from_bytes(hash.as_slice()),
+            None => Err(eg!("root hash key not found at this depth and version")),
         }
     }
 
@@ -347,6 +365,24 @@ impl<'a, D: MerkleDB> ImmutablePersistentMerkleTree<'a, D> {
         match self.store.get(&store_key)? {
             Some(hash) => BLSScalar::zei_from_bytes(hash.as_slice()),
             None => Err(eg!("root hash key not found")),
+        }
+    }
+
+    /// get tree root by depth and version.
+    pub fn get_root_with_depth_and_version(&self, depth: usize, version: u64) -> Result<BLSScalar> {
+        if version == 0 {
+            return Ok(BLSScalar::zero());
+        }
+
+        let mut pos = 0u64;
+        for i in 0..(TREE_DEPTH - depth) {
+            pos += 3u64.pow(i as u32);
+        }
+        let mut store_key = KEY_PAD.to_vec();
+        store_key.extend(pos.to_be_bytes());
+        match self.store.get_v(&store_key, version)? {
+            Some(hash) => BLSScalar::zei_from_bytes(hash.as_slice()),
+            None => Err(eg!("root hash key not found at this depth and version")),
         }
     }
 

--- a/accumulators/src/merkle_tree.rs
+++ b/accumulators/src/merkle_tree.rs
@@ -195,7 +195,7 @@ impl<'a, D: MerkleDB> PersistentMerkleTree<'a, D> {
         Ok(Proof {
             nodes: nodes,
             root: self.get_root_with_depth(depth)?,
-            root_version: 1,
+            root_version: self.version(),
             uid: id,
         })
     }
@@ -325,7 +325,7 @@ impl<'a, D: MerkleDB> ImmutablePersistentMerkleTree<'a, D> {
         Ok(Proof {
             nodes: nodes,
             root: self.get_root_with_depth(depth)?,
-            root_version: 1,
+            root_version: self.version(),
             uid: id,
         })
     }
@@ -396,7 +396,7 @@ pub struct Proof {
     /// current root.
     pub root: BLSScalar,
     /// current root version.
-    pub root_version: usize,
+    pub root_version: u64,
     /// leaf's uid.
     pub uid: u64,
 }

--- a/api/src/anon_xfr/abar_to_bar.rs
+++ b/api/src/anon_xfr/abar_to_bar.rs
@@ -52,12 +52,12 @@ pub struct ConvertAbarBarProof {
     commitment_eq_proof: ZKPartProof,
     spending_proof: Abar2BarPlonkProof,
     merkle_root: BLSScalar,
-    merkle_root_version: usize,
+    merkle_root_version: u64,
 }
 
 impl ConvertAbarBarProof {
     #[allow(dead_code)]
-    pub fn get_merkle_root_version(&self) -> usize {
+    pub fn get_merkle_root_version(&self) -> u64 {
         return self.merkle_root_version;
     }
 }
@@ -85,7 +85,7 @@ pub struct AbarToBarBody {
     /// The Merkle root hash
     pub merkle_root: BLSScalar,
     /// The Merkle root version
-    pub merkle_root_version: usize,
+    pub merkle_root_version: u64,
     /// The owner memo
     pub memo: Option<OwnerMemo>,
 }

--- a/api/src/anon_xfr/anon_fee.rs
+++ b/api/src/anon_xfr/anon_fee.rs
@@ -41,7 +41,7 @@ pub struct AnonFeeBody {
     pub input: Nullifier,
     pub output: AnonBlindAssetRecord,
     pub merkle_root: BLSScalar,
-    pub merkle_root_version: usize,
+    pub merkle_root_version: u64,
     pub owner_memo: OwnerMemo,
 }
 
@@ -183,7 +183,7 @@ pub fn verify_anon_fee_note(
 pub struct AnonFeeProof {
     pub snark_proof: SnarkProof,
     pub merkle_root: BLSScalar,
-    pub merkle_root_version: usize,
+    pub merkle_root_version: u64,
 }
 
 fn prove_anon_fee<R: CryptoRng + RngCore>(

--- a/api/src/anon_xfr/structs.rs
+++ b/api/src/anon_xfr/structs.rs
@@ -49,7 +49,7 @@ pub struct AXfrBody {
     pub inputs: Vec<Nullifier>,
     pub outputs: Vec<AnonBlindAssetRecord>,
     pub merkle_root: BLSScalar,
-    pub merkle_root_version: usize,
+    pub merkle_root_version: u64,
     pub owner_memos: Vec<OwnerMemo>,
 }
 
@@ -73,7 +73,7 @@ impl AnonBlindAssetRecord {
 pub struct MTLeafInfo {
     pub path: MTPath,
     pub root: BLSScalar,
-    pub root_version: usize,
+    pub root_version: u64,
     pub uid: u64,
 }
 


### PR DESCRIPTION
We use store's height to replace default merkle version, 
and in the platform, no need another storage to handle it.
And ImmutablePersistentMerkleTree use lastest versioned store.