### PR TITLE
Cleanup for delegated Chaum-Pedersen

### DIFF
--- a/api/src/anon_xfr/abar_to_bar.rs
+++ b/api/src/anon_xfr/abar_to_bar.rs
@@ -23,10 +23,10 @@ use zei_algebra::{
 };
 use zei_crypto::basic::ristretto_pedersen_comm::RistrettoPedersenCommitment;
 use zei_crypto::{
-    field_simulation::{SimFr, BIT_PER_LIMB, NUM_OF_LIMBS},
-    pc_eq_rescue_zk_part::{
-        prove_pc_eq_rescue_external, verify_pc_eq_rescue_external, NonZKState, ZKPartProof,
+    delegated_chaum_pedersen::{
+        prove_delegated_chaum_pedersen, verify_delegated_chaum_pedersen, NonZKState, ZKPartProof,
     },
+    field_simulation::{SimFr, BIT_PER_LIMB, NUM_OF_LIMBS},
 };
 use zei_plonk::{
     plonk::{
@@ -141,7 +141,7 @@ pub fn gen_abar_to_bar_note<R: CryptoRng + RngCore>(
     let point_q = pc_gens.commit(y, delta);
 
     // 4. compute the non-ZK part of the proof
-    let (commitment_eq_proof, non_zk_state, beta, lambda) = prove_pc_eq_rescue_external(
+    let (commitment_eq_proof, non_zk_state, beta, lambda) = prove_delegated_chaum_pedersen(
         prng,
         &x,
         &gamma,
@@ -254,7 +254,7 @@ pub fn verify_abar_to_bar_note(
     let input = note.body.input;
 
     // 2. verify equality of committed values
-    let (beta, lambda) = verify_pc_eq_rescue_external(
+    let (beta, lambda) = verify_delegated_chaum_pedersen(
         &pc_gens,
         &com_amount,
         &com_asset_type,

--- a/api/src/anon_xfr/bar_to_abar.rs
+++ b/api/src/anon_xfr/bar_to_abar.rs
@@ -17,10 +17,10 @@ use zei_crypto::{
         hybrid_encryption::XPublicKey, rescue::RescueInstance,
         ristretto_pedersen_comm::RistrettoPedersenCommitment,
     },
-    field_simulation::{SimFr, BIT_PER_LIMB, NUM_OF_LIMBS},
-    pc_eq_rescue_zk_part::{
-        prove_pc_eq_rescue_external, verify_pc_eq_rescue_external, NonZKState, ZKPartProof,
+    delegated_chaum_pedersen::{
+        prove_delegated_chaum_pedersen, verify_delegated_chaum_pedersen, NonZKState, ZKPartProof,
     },
+    field_simulation::{SimFr, BIT_PER_LIMB, NUM_OF_LIMBS},
 };
 use zei_plonk::plonk::{
     constraint_system::{field_simulation::SimFrVar, rescue::StateVar, TurboConstraintSystem},
@@ -153,7 +153,7 @@ pub(crate) fn bar_to_abar<R: CryptoRng + RngCore>(
     ])[0];
 
     // 3. compute the non-ZK part of the proof
-    let (commitment_eq_proof, non_zk_state, beta, lambda) = prove_pc_eq_rescue_external(
+    let (commitment_eq_proof, non_zk_state, beta, lambda) = prove_delegated_chaum_pedersen(
         prng, &x, &gamma, &y, &delta, &pc_gens, &point_p, &point_q, &z,
     )
     .c(d!())?;
@@ -225,7 +225,7 @@ pub(crate) fn verify_bar_to_abar(
     };
 
     // 2. verify equality of committed values
-    let (beta, lambda) = verify_pc_eq_rescue_external(
+    let (beta, lambda) = verify_delegated_chaum_pedersen(
         &pc_gens,
         &com_amount,
         &com_asset_type,
@@ -591,8 +591,8 @@ mod test {
     use zei_crypto::basic::hybrid_encryption::{XPublicKey, XSecretKey};
     use zei_crypto::basic::rescue::RescueInstance;
     use zei_crypto::basic::ristretto_pedersen_comm::RistrettoPedersenCommitment;
+    use zei_crypto::delegated_chaum_pedersen::prove_delegated_chaum_pedersen;
     use zei_crypto::field_simulation::{SimFr, NUM_OF_LIMBS};
-    use zei_crypto::pc_eq_rescue_zk_part::prove_pc_eq_rescue_external;
 
     // helper function
     fn build_bar(
@@ -745,7 +745,7 @@ mod test {
         let z = z_instance.rescue(&[z_randomizer, x_in_bls12_381, y_in_bls12_381, pubkey_x])[0];
 
         // 2. compute the ZK part of the proof
-        let (proof, non_zk_state, beta, lambda) = prove_pc_eq_rescue_external(
+        let (proof, non_zk_state, beta, lambda) = prove_delegated_chaum_pedersen(
             &mut rng, &x, &gamma, &y, &delta, &pc_gens, &point_p, &point_q, &z,
         )
         .unwrap();

--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -24,7 +24,7 @@ use zei_algebra::{
     prelude::*,
     ristretto::RistrettoScalar,
 };
-use zei_crypto::pc_eq_rescue_zk_part::{NonZKState, ZKPartProof};
+use zei_crypto::delegated_chaum_pedersen::{NonZKState, ZKPartProof};
 use zei_plonk::{
     plonk::{
         constraint_system::ConstraintSystem,

--- a/crypto/src/delegated_chaum_pedersen.rs
+++ b/crypto/src/delegated_chaum_pedersen.rs
@@ -46,8 +46,7 @@ impl ZKPartProof {
     }
 }
 
-#[allow(unused)]
-pub fn prove_pc_eq_rescue_external<R: CryptoRng + RngCore>(
+pub fn prove_delegated_chaum_pedersen<R: CryptoRng + RngCore>(
     rng: &mut R,
     x: &RistrettoScalar,
     gamma: &RistrettoScalar,
@@ -179,8 +178,7 @@ pub fn prove_pc_eq_rescue_external<R: CryptoRng + RngCore>(
     Ok((proof, non_zk_state, beta, lambda))
 }
 
-#[allow(unused)]
-pub fn verify_pc_eq_rescue_external(
+pub fn verify_delegated_chaum_pedersen(
     pc_gens: &RistrettoPedersenCommitment,
     point_p: &RistrettoPoint,
     point_q: &RistrettoPoint,
@@ -251,7 +249,9 @@ pub fn verify_pc_eq_rescue_external(
 mod test {
     use crate::basic::rescue::RescueInstance;
     use crate::basic::ristretto_pedersen_comm::RistrettoPedersenCommitment;
-    use crate::pc_eq_rescue_zk_part::{prove_pc_eq_rescue_external, verify_pc_eq_rescue_external};
+    use crate::delegated_chaum_pedersen::{
+        prove_delegated_chaum_pedersen, verify_delegated_chaum_pedersen,
+    };
     use num_bigint::BigUint;
     use rand_chacha::ChaChaRng;
     use rand_core::SeedableRng;
@@ -286,12 +286,13 @@ mod test {
                 BLSScalar::zero(),
             ])[0];
 
-            let (proof, _, _, _) = prove_pc_eq_rescue_external(
+            let (proof, _, _, _) = prove_delegated_chaum_pedersen(
                 &mut rng, &x, &gamma, &y, &delta, &pc_gens, &point_p, &point_q, &z,
             )
             .unwrap();
 
-            let _ = verify_pc_eq_rescue_external(&pc_gens, &point_p, &point_q, &z, &proof).unwrap();
+            let _ =
+                verify_delegated_chaum_pedersen(&pc_gens, &point_p, &point_q, &z, &proof).unwrap();
         }
     }
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -13,5 +13,5 @@ pub mod anon_creds;
 pub mod basic;
 pub mod bulletproofs;
 pub mod conf_cred_reveal;
+pub mod delegated_chaum_pedersen;
 pub mod field_simulation;
-pub mod pc_eq_rescue_zk_part;


### PR DESCRIPTION
The documentation for the delegated Chaum-Pedersen protocol is now being done in Overleaf.

This PR is to rename that previous Pedersen commitment equality check to delegated Chaum-Pedersen. It is very difficult to find a name because this protocol is application-specific and is no longer proving the equality of two Pedersen commitments.

