### PR TITLE
Remove the common seed from the indexer

### DIFF
--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -72,7 +72,6 @@ pub struct NodeParamsSplitSpecial {
 
 pub const BULLET_PROOF_RANGE: usize = 32;
 pub const MAX_PARTY_NUMBER: usize = 128;
-const COMMON_SEED: [u8; 32] = [0u8; 32];
 pub const PRECOMPUTED_PARTY_NUMBER: usize = 6;
 pub const DEFAULT_BP_NUM_GENS: usize = 256;
 
@@ -145,7 +144,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,
@@ -180,7 +179,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,
@@ -235,7 +234,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,
@@ -264,7 +263,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,
@@ -311,7 +310,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,
@@ -365,7 +364,7 @@ impl ProverParams {
         let lagrange_pcs = load_lagrange_params(cs.size());
 
         let prover_params =
-            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref(), COMMON_SEED).unwrap();
+            preprocess_prover_with_lagrange(&cs, &pcs, lagrange_pcs.as_ref()).unwrap();
 
         Ok(ProverParams {
             bp_params: BulletproofParams::new()?,

--- a/plonk/src/plonk/constraint_system/turbo.rs
+++ b/plonk/src/plonk/constraint_system/turbo.rs
@@ -1203,8 +1203,7 @@ mod test {
         witness: &[PCS::Field],
         online_vars: &[PCS::Field],
     ) {
-        let common_seed = [0u8; 32];
-        let prover_params = preprocess_prover(cs, pcs, common_seed).unwrap();
+        let prover_params = preprocess_prover(cs, pcs).unwrap();
         let verifier_params_ref = &prover_params.verifier_params;
 
         let mut transcript = Transcript::new(b"TestTurboPlonk");

--- a/plonk/src/plonk/helpers.rs
+++ b/plonk/src/plonk/helpers.rs
@@ -620,7 +620,7 @@ mod test {
 
         let mut prng = ChaChaRng::from_seed([0_u8; 32]);
         let pcs = KZGCommitmentScheme::new(20, &mut prng);
-        let params = preprocess_prover(&cs, &pcs, [0u8; 32]).unwrap();
+        let params = preprocess_prover(&cs, &pcs).unwrap();
 
         let mut challenges = PlonkChallenges::<F>::new();
         challenges.insert_gamma_delta(one, zero).unwrap();

--- a/plonk/src/plonk/prover.rs
+++ b/plonk/src/plonk/prover.rs
@@ -36,7 +36,7 @@ use zei_algebra::prelude::*;
 /// use rand_chacha::ChaChaRng;
 /// use zei_algebra::{prelude::*, bls12_381::BLSScalar};
 ///
-/// let mut prng = ChaChaRng::from_seed([1u8; 32]);
+/// let mut prng = ChaChaRng::from_seed([0u8; 32]);
 /// let pcs = KZGCommitmentScheme::new(20, &mut prng);
 /// let mut cs = TurboConstraintSystem::new();
 ///
@@ -50,10 +50,9 @@ use zei_algebra::prelude::*;
 /// cs.insert_add_gate(var_one, var_two, var_three);
 /// cs.pad();
 ///
-/// let common_seed = [0u8; 32];
 /// let proof = {
 ///     let witness = cs.get_and_clear_witness();
-///     let prover_params = preprocess_prover(&cs, &pcs, common_seed).unwrap();
+///     let prover_params = preprocess_prover(&cs, &pcs).unwrap();
 ///     let mut transcript = Transcript::new(b"Test");
 ///     prover(
 ///         &mut prng,
@@ -66,7 +65,7 @@ use zei_algebra::prelude::*;
 ///         .unwrap()
 /// };
 ///
-/// let verifier_params = preprocess_verifier(&cs, &pcs, common_seed).unwrap();
+/// let verifier_params = preprocess_verifier(&cs, &pcs).unwrap();
 /// let mut transcript = Transcript::new(b"Test");
 /// assert!(
 ///     verifier(&mut transcript, &pcs, &cs, &verifier_params, &[], &proof).is_ok()

--- a/plonk/src/plonk/setup.rs
+++ b/plonk/src/plonk/setup.rs
@@ -157,9 +157,8 @@ pub fn choose_ks<R: CryptoRng + RngCore, F: Scalar>(
 pub fn preprocess_prover<PCS: PolyComScheme, CS: ConstraintSystem<Field = PCS::Field>>(
     cs: &CS,
     pcs: &PCS,
-    prg_seed: [u8; 32],
 ) -> Result<PlonkPK<PCS>> {
-    preprocess_prover_with_lagrange(cs, pcs, None, prg_seed)
+    preprocess_prover_with_lagrange(cs, pcs, None)
 }
 
 /// Indexer that uses Lagrange bases
@@ -170,9 +169,8 @@ pub fn preprocess_prover_with_lagrange<
     cs: &CS,
     pcs: &PCS,
     lagrange_pcs: Option<&PCS>,
-    prg_seed: [u8; 32],
 ) -> Result<PlonkPK<PCS>> {
-    let mut prng = ChaChaRng::from_seed(prg_seed);
+    let mut prng = ChaChaRng::from_seed([0u8; 32]);
     let n_wires_per_gate = CS::n_wires_per_gate();
     let n = cs.size();
     let m = cs.quot_eval_dom_size();
@@ -311,9 +309,8 @@ pub fn preprocess_prover_with_lagrange<
 pub fn preprocess_verifier<PCS: PolyComScheme, CS: ConstraintSystem<Field = PCS::Field>>(
     cs: &CS,
     pcs: &PCS,
-    prg_seed: [u8; 32],
 ) -> Result<PlonkVK<PCS>> {
-    let prover_params = preprocess_prover(cs, pcs, prg_seed).c(d!())?;
+    let prover_params = preprocess_prover(cs, pcs).c(d!())?;
     Ok(prover_params.verifier_params)
 }
 


### PR DESCRIPTION
Since our entire library has been using the same seed for TurboPlonk's indexing, and fixing this seed makes sense---it does not  break the soundness guarantee, this PR removes the common seed from the function signature.

