### PR TITLE
New TurboPlonk

### DIFF
--- a/algebra/src/bls12_381.rs
+++ b/algebra/src/bls12_381.rs
@@ -632,6 +632,13 @@ impl<'a> SubAssign<&'a BLSG1> for BLSG1 {
     }
 }
 
+impl<'a> MulAssign<&'a BLSScalar> for BLSG1 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &'a BLSScalar) {
+        self.0.mul_assign(rhs.0.clone())
+    }
+}
+
 impl Group for BLSG2 {
     type ScalarType = BLSScalar;
     const COMPRESSED_LEN: usize = 96;

--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -573,6 +573,6 @@ mod test {
             let g_i = pcs.public_parameter_group_1[i].clone();
             expected_committed_value = expected_committed_value.add(&g_i.mul(&coef));
         }
-        assert_eq!(expected_committed_value, commitment.value);
+        assert_eq!(expected_committed_value, commitment.0);
     }
 }

--- a/plonk/src/plonk/helpers.rs
+++ b/plonk/src/plonk/helpers.rs
@@ -7,6 +7,7 @@ use crate::poly_commit::{
     field_polynomial::FpPolynomial,
     pcs::{HomomorphicPolyComElem, PolyComScheme},
 };
+use std::cmp::min;
 use zei_algebra::prelude::*;
 
 /// Build the base group.
@@ -344,20 +345,23 @@ fn linearization<F: Scalar, PCSType: HomomorphicPolyComElem<Scalar = F>>(
     perms_eval_beta: &[&F],
     sigma_eval_g_beta: &F,
     challenges: &PlonkChallenges<F>,
+    q_polys: &[PCSType],
+    n_q_polys: usize,
 ) -> PCSType {
     let (gamma, delta) = challenges.get_gamma_delta().unwrap();
     let alpha = challenges.get_alpha().unwrap();
+    let beta = challenges.get_beta().unwrap();
 
     // 1. sum_{i=1..n_selectors} wi * qi(X)
-    let mut l = selectors[0].exp(&wires[0]);
+    let mut l = selectors[0].mul(&wires[0]);
     for i in 1..selectors.len() {
-        l.op_assign(&selectors[i].exp(&wires[i]));
+        l.add_assign(&selectors[i].mul(&wires[i]));
     }
 
     // 2. \Sigma(X) [ alpha * prod_{j=1..n_wires_per_gate} (fj(beta) + gamma * kj * beta + delta)
     //              + alpha^2 * L1(beta)]
     let sigma_scalar = compute_sigma_scalar_in_l(n, witness_polys_eval_beta, k, challenges);
-    l.op_assign(&sigma.exp(&sigma_scalar));
+    l.add_assign(&sigma.mul(&sigma_scalar));
 
     // 3. - perm_{n_wires_per_gate}(X) [alpha * \Sigma(g*beta) * gamma
     //    * prod_{j=1..n_wires_per_gate-1}(fj(beta) + gamma * perm_j(beta) + delta)]
@@ -368,7 +372,23 @@ fn linearization<F: Scalar, PCSType: HomomorphicPolyComElem<Scalar = F>>(
             .add(delta);
         b.mul_assign(&bi);
     }
-    l.op_assign(&last_extended_perm.exp(&b).inv());
+    l.sub_assign(&last_extended_perm.mul(&b));
+
+    let mut z_h_eval_beta = beta.pow(&[n as u64]);
+    z_h_eval_beta.sub_assign(&F::one());
+    z_h_eval_beta = z_h_eval_beta.neg();
+
+    // 4. subtract the combined q polynomial
+    // Given value \beta, and homomorphic polynomial commitments/openings {qi(X)}_{i=0..m-1},
+    // compute \sum_{i=0..m-1} \beta^{i*n} * qi(X)
+    let factor = beta.pow(&[n_q_polys as u64]);
+    let mut exponent = factor * z_h_eval_beta;
+    let mut q_poly_combined = q_polys[0].clone();
+    for q_poly in q_polys.iter().skip(1) {
+        q_poly_combined.add_assign(&q_poly.mul(&exponent));
+        exponent.mul_assign(&factor);
+    }
+    l.sub_assign(&q_poly_combined);
     l
 }
 
@@ -383,6 +403,8 @@ pub(super) fn linearization_polynomial_opening<
     perms_eval_beta: &[&PCS::Field],
     sigma_eval_g_beta: &PCS::Field,
     challenges: &PlonkChallenges<PCS::Field>,
+    q_polys: &[PCS::Opening],
+    n_q_polys: usize,
 ) -> PCS::Opening {
     let w = CS::eval_selector_multipliers(witness_polys_eval_beta).unwrap(); // safe unwrap
     linearization::<PCS::Field, PCS::Opening>(
@@ -396,6 +418,8 @@ pub(super) fn linearization_polynomial_opening<
         perms_eval_beta,
         sigma_eval_g_beta,
         challenges,
+        q_polys,
+        n_q_polys,
     )
 }
 
@@ -410,6 +434,8 @@ pub(super) fn linearization_commitment<
     perms_eval_beta: &[&PCS::Field],
     sigma_eval_g_beta: &PCS::Field,
     challenges: &PlonkChallenges<PCS::Field>,
+    q_polys: &[PCS::Commitment],
+    n_q_polys: usize,
 ) -> PCS::Commitment {
     let w = CS::eval_selector_multipliers(witness_polys_eval_beta).unwrap(); // safe unwrap
     linearization::<PCS::Field, PCS::Commitment>(
@@ -423,6 +449,8 @@ pub(super) fn linearization_commitment<
         perms_eval_beta,
         sigma_eval_g_beta,
         challenges,
+        q_polys,
+        n_q_polys,
     )
 }
 
@@ -518,7 +546,7 @@ pub(super) fn derive_q_eval_beta<PCS: PolyComScheme>(
     let alpha = challenges.get_alpha().unwrap();
     let (gamma, delta) = challenges.get_gamma_delta().unwrap();
 
-    let term0 = proof.l_eval_beta.add(public_vars_eval_beta);
+    let term0 = public_vars_eval_beta;
     let mut term1 = alpha.mul(&proof.sigma_eval_g_beta);
     let n_wires_per_gate = &proof.witness_polys_eval_beta.len();
     for i in 0..n_wires_per_gate - 1 {
@@ -553,35 +581,30 @@ pub(crate) fn split_q_and_commit<PCS: PolyComScheme>(
 ) -> Result<(Vec<PCS::Commitment>, Vec<PCS::Opening>)> {
     let mut c_q_polys = vec![];
     let mut o_q_polys = vec![];
+    let coefs_len = q.get_coefs_ref().len();
+
+    println!("n here = {}", n);
+
     for i in 0..n_wires_per_gate {
-        let coefs = if i < n_wires_per_gate - 1 {
-            q.get_coefs_ref()[i * n..(i + 1) * n].to_vec()
+        let coefs_start = i * n;
+        let coefs_end = if i == n_wires_per_gate - 1 {
+            coefs_len
         } else {
-            q.get_coefs_ref()[(n_wires_per_gate - 1) * n..].to_vec()
+            (i + 1) * n
+        };
+        let coefs = if coefs_start < coefs_len {
+            q.get_coefs_ref()[coefs_start..min(coefs_len, coefs_end)].to_vec()
+        } else {
+            vec![]
         };
         let q_poly = FpPolynomial::from_coefs(coefs);
+        println!("The {}-th polynomial = {}", i + 1, q_poly.degree());
         let (c_q, o_q) = pcs.commit(q_poly).c(d!(PlonkError::CommitmentError))?;
         c_q_polys.push(c_q);
         o_q_polys.push(o_q);
     }
-    Ok((c_q_polys, o_q_polys))
-}
 
-/// Given value \beta, and homomorphic polynomial commitments/openings {qi(X)}_{i=0..m-1},
-/// compute \sum_{i=0..m-1} \beta^{i*n} * qi(X)
-pub(crate) fn combine_q_polys<F: Scalar, PCSType: HomomorphicPolyComElem<Scalar = F> + Clone>(
-    q_polys: &[PCSType],
-    beta: &F,
-    n: usize,
-) -> PCSType {
-    let factor = beta.pow(&[n as u64]);
-    let mut exponent = factor;
-    let mut q_poly_combined = q_polys[0].clone();
-    for q_poly in q_polys.iter().skip(1) {
-        q_poly_combined.op_assign(&q_poly.exp(&exponent));
-        exponent.mul_assign(&factor);
-    }
-    q_poly_combined
+    Ok((c_q_polys, o_q_polys))
 }
 
 #[cfg(test)]

--- a/plonk/src/plonk/helpers.rs
+++ b/plonk/src/plonk/helpers.rs
@@ -43,9 +43,7 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Gamma and Delta.
     pub(super) fn insert_gamma_delta(&mut self, gamma: F, delta: F) -> Result<()> {
         if self.challenges.is_empty() {
-            println!("gamma: {:?}", gamma);
             self.challenges.push(gamma);
-            println!("delta: {:?}", delta);
             self.challenges.push(delta);
             Ok(())
         } else {
@@ -56,9 +54,7 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Alpha.
     pub(super) fn insert_alpha(&mut self, alpha: F) -> Result<()> {
         if self.challenges.len() == 2 {
-            println!("alpha = 0: {:?}", alpha);
-            //self.challenges.push(alpha);
-            self.challenges.push(F::zero());
+            self.challenges.push(alpha);
             Ok(())
         } else {
             Err(eg!())
@@ -68,7 +64,6 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Beta.
     pub(super) fn insert_beta(&mut self, beta: F) -> Result<()> {
         if self.challenges.len() == 3 {
-            println!("beta: {:?}", beta);
             self.challenges.push(beta);
             Ok(())
         } else {

--- a/plonk/src/plonk/helpers.rs
+++ b/plonk/src/plonk/helpers.rs
@@ -43,7 +43,9 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Gamma and Delta.
     pub(super) fn insert_gamma_delta(&mut self, gamma: F, delta: F) -> Result<()> {
         if self.challenges.is_empty() {
+            println!("gamma: {:?}", gamma);
             self.challenges.push(gamma);
+            println!("delta: {:?}", delta);
             self.challenges.push(delta);
             Ok(())
         } else {
@@ -54,6 +56,7 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Alpha.
     pub(super) fn insert_alpha(&mut self, alpha: F) -> Result<()> {
         if self.challenges.len() == 2 {
+            println!("alpha = 0: {:?}", alpha);
             //self.challenges.push(alpha);
             self.challenges.push(F::zero());
             Ok(())
@@ -65,6 +68,7 @@ impl<F: Scalar> PlonkChallenges<F> {
     /// Insert Beta.
     pub(super) fn insert_beta(&mut self, beta: F) -> Result<()> {
         if self.challenges.len() == 3 {
+            println!("beta: {:?}", beta);
             self.challenges.push(beta);
             Ok(())
         } else {
@@ -383,7 +387,7 @@ fn linearization<F: Scalar, PCSType: HomomorphicPolyComElem<Scalar = F>>(
     // compute \sum_{i=0..m-1} \beta^{i*n} * qi(X)
     let factor = beta.pow(&[n_q_polys as u64]);
     let mut exponent = z_h_eval_beta * factor;
-    let mut q_poly_combined = q_polys[0].clone();
+    let mut q_poly_combined = q_polys[0].clone().mul(&z_h_eval_beta);
     for q_poly in q_polys.iter().skip(1) {
         q_poly_combined.add_assign(&q_poly.mul(&exponent));
         exponent.mul_assign(&factor);

--- a/plonk/src/plonk/prover.rs
+++ b/plonk/src/plonk/prover.rs
@@ -1,6 +1,4 @@
-use crate::plonk::transcript::{
-    transcript_get_challenge_field_elem, transcript_get_plonk_challenge_u,
-};
+use crate::plonk::transcript::transcript_get_plonk_challenge_u;
 use crate::plonk::{
     constraint_system::ConstraintSystem,
     errors::PlonkError,
@@ -20,7 +18,6 @@ use crate::poly_commit::{
 };
 use merlin::Transcript;
 use zei_algebra::prelude::*;
-use zei_crypto::basic::matrix_sigma::SigmaTranscript;
 
 /// PLONK Prover: it produces a proof that `witness` satisfies the constraint system `cs`
 /// Proof verifier must use a transcript with same state as prover and match the public parameters

--- a/plonk/src/plonk/setup.rs
+++ b/plonk/src/plonk/setup.rs
@@ -5,7 +5,7 @@ use crate::plonk::{
 };
 use crate::poly_commit::{
     field_polynomial::{primitive_nth_root_of_unity, FpPolynomial},
-    pcs::{BatchProofEval, PolyComScheme},
+    pcs::PolyComScheme,
 };
 use rand_chacha::ChaChaRng;
 use zei_algebra::prelude::*;
@@ -14,10 +14,10 @@ use zei_algebra::prelude::*;
 /// PCS is generic in the commitment group C, the eval proof type E,
 /// and Field elements F.
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
-pub struct PlonkProof<C, E, F> {
+pub struct PlonkProof<C, F> {
     /// the witness polynomial commitments.
     pub(crate) c_witness_polys: Vec<C>,
-    /// the splitted quotient polynomial commitments
+    /// the split quotient polynomial commitments
     pub(crate) c_q_polys: Vec<C>,
     /// the sigma polynomial commitment.
     pub(crate) c_sigma: C,
@@ -27,18 +27,15 @@ pub struct PlonkProof<C, E, F> {
     pub(crate) sigma_eval_g_beta: F,
     /// the openings of permutation polynomials at beta.
     pub(crate) perms_eval_beta: Vec<F>,
-    /// the opening of linearization polynomial at beta.
-    pub(crate) l_eval_beta: F,
-    /// Batch proof for polynomial evaluation.
-    pub(crate) batch_eval_proof: BatchProofEval<C, E>,
+    /// The commitment for the first witness polynomial.
+    pub(crate) eval_proof_1: C,
+    /// The commitment for the second witness polynomial.
+    pub(crate) eval_proof_2: C,
 }
 
 /// Define the PLONK proof by given `PolyComScheme`.
-pub type PlonkPf<PCS> = PlonkProof<
-    <PCS as PolyComScheme>::Commitment,
-    <PCS as PolyComScheme>::EvalProof,
-    <PCS as PolyComScheme>::Field,
->;
+pub type PlonkPf<PCS> =
+    PlonkProof<<PCS as PolyComScheme>::Commitment, <PCS as PolyComScheme>::Field>;
 
 /// PLONK prover parameters.
 #[derive(Debug, Serialize, Deserialize)]

--- a/plonk/src/plonk/transcript.rs
+++ b/plonk/src/plonk/transcript.rs
@@ -79,3 +79,11 @@ pub(crate) fn transcript_get_plonk_challenge_delta<F: Scalar>(
 ) -> F {
     transcript_get_challenge_field_elem(transcript, group_order, b"delta")
 }
+
+/// Return the challenge result by label: "u"
+pub(crate) fn transcript_get_plonk_challenge_u<F: Scalar>(
+    transcript: &mut Transcript,
+    group_order: usize,
+) -> F {
+    transcript_get_challenge_field_elem(transcript, group_order, b"u")
+}

--- a/plonk/src/plonk/verifier.rs
+++ b/plonk/src/plonk/verifier.rs
@@ -1,6 +1,4 @@
-use crate::plonk::transcript::{
-    transcript_get_challenge_field_elem, transcript_get_plonk_challenge_u,
-};
+use crate::plonk::transcript::transcript_get_plonk_challenge_u;
 use crate::plonk::{
     constraint_system::ConstraintSystem,
     errors::PlonkError,
@@ -17,7 +15,6 @@ use crate::plonk::{
 use crate::poly_commit::{pcs::PolyComScheme, transcript::PolyComTranscript};
 use merlin::Transcript;
 use zei_algebra::prelude::*;
-use zei_crypto::basic::matrix_sigma::SigmaTranscript;
 
 /// Verify a proof for a constraint system previously preprocessed into `cs_params`
 /// State of the transcript must match prover state of the transcript

--- a/plonk/src/plonk/verifier.rs
+++ b/plonk/src/plonk/verifier.rs
@@ -116,8 +116,8 @@ pub fn verifier<PCS: PolyComScheme, CS: ConstraintSystem<Field = PCS::Field>>(
         &values[..],
         &proof.eval_proof_1,
     )
-    .c(d!(PlonkError::VerificationError))?;
-    pcs.verify(
+    .c(d!(PlonkError::VerificationError))
+    /*pcs.verify(
         transcript,
         &proof.c_sigma,
         cs_params.cs_size + 2,
@@ -125,5 +125,5 @@ pub fn verifier<PCS: PolyComScheme, CS: ConstraintSystem<Field = PCS::Field>>(
         &proof.sigma_eval_g_beta,
         &proof.eval_proof_2,
     )
-    .c(d!(PlonkError::VerificationError))
+    .c(d!(PlonkError::VerificationError))*/
 }

--- a/plonk/src/poly_commit/field_polynomial.rs
+++ b/plonk/src/poly_commit/field_polynomial.rs
@@ -165,7 +165,7 @@ impl<F: Scalar> FpPolynomial<F> {
         }
     }
 
-    /// Tests if polynomial is the zero polynomial
+    /// Test if polynomial is the zero polynomial
     /// # Example:
     /// ```
     /// use zei_plonk::poly_commit::field_polynomial::FpPolynomial;

--- a/plonk/src/poly_commit/kzg_poly_com.rs
+++ b/plonk/src/poly_commit/kzg_poly_com.rs
@@ -40,7 +40,7 @@ use zei_algebra::{
 
 /// KZG commitment scheme about the `Group`.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct KZGCommitment<G>(G);
+pub struct KZGCommitment<G>(pub G);
 
 impl<'a, G> ToBytes for KZGCommitment<G>
 where
@@ -130,7 +130,7 @@ impl<F: Scalar> HomomorphicPolyComElem for FpPolynomial<F> {
 
 /// KZG eval proof.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-pub struct KZGEvalProof<G1>(G1);
+pub struct KZGEvalProof<G1>(pub G1);
 
 impl<G: Group> ToBytes for KZGEvalProof<G> {
     fn to_bytes(&self) -> Vec<u8> {

--- a/plonk/src/poly_commit/kzg_poly_com.rs
+++ b/plonk/src/poly_commit/kzg_poly_com.rs
@@ -40,59 +40,49 @@ use zei_algebra::{
 
 /// KZG commitment scheme about the `Group`.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct KZGCommitment<G> {
-    /// the `Group` elements.
-    pub value: G,
-}
+pub struct KZGCommitment<G>(G);
 
 impl<'a, G> ToBytes for KZGCommitment<G>
 where
     G: Group,
 {
     fn to_bytes(&self) -> Vec<u8> {
-        self.value.to_compressed_bytes()
+        self.0.to_compressed_bytes()
     }
 }
 
 impl HomomorphicPolyComElem for KZGCommitment<BLSG1> {
     type Scalar = BLSScalar;
     fn get_base() -> Self {
-        KZGCommitment {
-            value: BLSG1::get_base(),
-        }
+        KZGCommitment(BLSG1::get_base())
     }
 
     fn get_identity() -> Self {
-        KZGCommitment {
-            value: BLSG1::get_identity(),
-        }
+        KZGCommitment(BLSG1::get_identity())
     }
 
-    fn op(&self, other: &Self) -> Self {
-        KZGCommitment {
-            value: self.value.add(&other.value),
-        }
+    fn add(&self, other: &Self) -> Self {
+        KZGCommitment(self.0.add(&other.0))
     }
 
-    fn op_assign(&mut self, other: &Self) {
-        self.value = self.value.add(&other.value); // TODO have real add_assign
+    fn add_assign(&mut self, other: &Self) {
+        self.0.add_assign(&other.0)
     }
 
-    fn exp(&self, exp: &BLSScalar) -> Self {
-        KZGCommitment {
-            value: self.value.mul(exp),
-        }
+    fn sub(&self, other: &Self) -> Self {
+        KZGCommitment(self.0.sub(&other.0))
     }
 
-    fn exp_assign(&mut self, exp: &BLSScalar) {
-        self.value = self.value.mul(&exp); // TODO have real add_assign
+    fn sub_assign(&mut self, other: &Self) {
+        self.0.sub_assign(&other.0)
     }
 
-    fn inv(&self) -> Self {
-        let minus_one_scalar = BLSScalar::one().neg();
-        KZGCommitment {
-            value: self.value.mul(&minus_one_scalar),
-        }
+    fn mul(&self, exp: &BLSScalar) -> Self {
+        KZGCommitment(self.0.mul(exp))
+    }
+
+    fn mul_assign(&mut self, exp: &BLSScalar) {
+        self.0.mul_assign(&exp)
     }
 }
 
@@ -113,24 +103,28 @@ impl<F: Scalar> HomomorphicPolyComElem for FpPolynomial<F> {
         unimplemented!()
     }
 
-    fn op(&self, other: &Self) -> Self {
+    fn add(&self, other: &Self) -> Self {
         self.add(other)
     }
 
-    fn op_assign(&mut self, other: &Self) {
+    fn add_assign(&mut self, other: &Self) {
         self.add_assign(other)
     }
 
-    fn exp(&self, exp: &F) -> Self {
+    fn sub(&self, other: &Self) -> Self {
+        self.sub(other)
+    }
+
+    fn sub_assign(&mut self, other: &Self) {
+        self.sub_assign(other)
+    }
+
+    fn mul(&self, exp: &F) -> Self {
         self.mul_scalar(exp)
     }
 
-    fn exp_assign(&mut self, exp: &F) {
+    fn mul_assign(&mut self, exp: &F) {
         self.mul_scalar_assign(exp)
-    }
-
-    fn inv(&self) -> Self {
-        self.neg()
     }
 }
 
@@ -258,7 +252,6 @@ pub type KZGCommitmentSchemeBLS = KZGCommitmentScheme<BLSPairingEngine>;
 impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
     type Field = BLSScalar;
     type Commitment = KZGCommitment<BLSG1>;
-    type EvalProof = KZGEvalProof<BLSG1>;
     type Opening = FpPolynomial<Self::Field>;
 
     fn max_degree(&self) -> usize {
@@ -288,12 +281,7 @@ impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
             &pub_param_group_1_as_ref[..],
         );
 
-        Ok((
-            KZGCommitment {
-                value: commitment_value,
-            },
-            polynomial,
-        ))
+        Ok((KZGCommitment(commitment_value), polynomial))
     }
 
     fn opening(&self, polynomial: &FpPolynomial<Self::Field>) -> Self::Opening {
@@ -314,14 +302,14 @@ impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
         blinds: &[Self::Field],
         zeroing_degree: usize,
     ) -> Self::Commitment {
-        let mut commitment = commitment.value.clone();
+        let mut commitment = commitment.0.clone();
         for (i, blind) in blinds.iter().enumerate() {
             let mut blind = blind.clone();
             commitment = commitment + &(self.public_parameter_group_1[i] * &blind);
             blind = blind.neg();
             commitment = commitment + &(self.public_parameter_group_1[zeroing_degree + i] * &blind);
         }
-        KZGCommitment { value: commitment }
+        KZGCommitment(commitment)
     }
 
     fn commitment_from_opening(&self, opening: &Self::Opening) -> Self::Commitment {
@@ -338,13 +326,13 @@ impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
         opening
     }
 
-    fn prove_eval(
+    fn prove(
         &self,
         _transcript: &mut Transcript,
         opening: &FpPolynomial<Self::Field>,
         x: &Self::Field,
         max_degree: usize,
-    ) -> Result<(Self::Field, Self::EvalProof)> {
+    ) -> Result<Self::Commitment> {
         let polynomial = opening;
         let evaluation = polynomial.eval(x);
 
@@ -373,20 +361,18 @@ impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
             return Err(eg!(PolyComSchemeError::PCSProveEvalError));
         }
 
-        let proof_value = self.commit(quotient_polynomial).unwrap().0.value;
-
-        let res = (evaluation, KZGEvalProof::<BLSG1>(proof_value));
-        Ok(res)
+        let proof_value = self.commit(quotient_polynomial).unwrap().0;
+        Ok(proof_value)
     }
 
-    fn verify_eval(
+    fn verify(
         &self,
         _transcript: &mut Transcript,
         c: &Self::Commitment,
         _degree: usize,
         x: &Self::Field,
         y: &Self::Field,
-        proof: &Self::EvalProof,
+        proof: &Self::Commitment,
     ) -> Result<()> {
         let g1_0 = self.public_parameter_group_1[0].clone();
         let g2_0 = self.public_parameter_group_2[0].clone();
@@ -395,7 +381,7 @@ impl<'b> PolyComScheme for KZGCommitmentSchemeBLS {
         let x_minus_point_group_element_group_2 = &g2_1.sub(&g2_0.mul(x));
 
         // e(g1^{P(X)-P(x)},g2)
-        let left_pairing_eval = BLSPairingEngine::pairing(&c.value.sub(&g1_0.mul(y)), &g2_0);
+        let left_pairing_eval = BLSPairingEngine::pairing(&c.0.sub(&g1_0.mul(y)), &g2_0);
 
         // e(g1^{Q(X)},g1^{X-x})
         let right_pairing_eval =
@@ -498,27 +484,15 @@ mod tests_kzg_impl {
         // Add two polynomials
         let poly_sum = poly1.add(&poly2);
         let (commitment_sum, _) = pcs.commit(poly_sum).unwrap();
-        let commitment_sum_computed = commitment1.op(&commitment2);
-        assert_eq!(commitment_sum.value, commitment_sum_computed.value);
-
-        let minus_two = two.neg();
-        let minus_three = three.neg();
-        let minus_six = six.neg();
-        // Negating the coefficients of the polynomial
-        let poly1_neg = FpPolynomial::from_coefs(vec![minus_two, minus_three, minus_six]);
-        let (commitment_poly1_neg, _) = pcs.commit(poly1_neg).unwrap();
-        let commitment_poly1_neg_hom = commitment1.inv();
-        assert_eq!(commitment_poly1_neg_hom.value, commitment_poly1_neg.value);
+        let commitment_sum_computed = commitment1.add(&commitment2);
+        assert_eq!(commitment_sum, commitment_sum_computed);
 
         // Multiplying all the coefficients of a polynomial by some value
         let exponent = four.add(&one);
         let poly1_mult_5 = poly1.mul_scalar(&exponent);
         let (commitment_poly1_mult_5, _) = pcs.commit(poly1_mult_5).unwrap();
-        let commitment_poly1_mult_5_hom = commitment1.exp(&exponent);
-        assert_eq!(
-            commitment_poly1_mult_5.value,
-            commitment_poly1_mult_5_hom.value
-        );
+        let commitment_poly1_mult_5_hom = commitment1.mul(&exponent);
+        assert_eq!(commitment_poly1_mult_5, commitment_poly1_mult_5_hom);
     }
 
     #[test]
@@ -552,7 +526,7 @@ mod tests_kzg_impl {
             let g_i = pcs.public_parameter_group_1[i].clone();
             expected_committed_value = expected_committed_value.add(&g_i.mul(&coef));
         }
-        assert_eq!(expected_committed_value, commitment.value);
+        assert_eq!(expected_committed_value, commitment.0);
     }
 
     #[test]
@@ -577,7 +551,7 @@ mod tests_kzg_impl {
 
         // Check that an error is returned if the degree of the polynomial exceeds the maximum degree.
         let wrong_max_degree = 1;
-        let res = pcs.prove_eval(
+        let res = pcs.prove(
             &mut not_needed_transcript,
             &opening,
             &point,
@@ -585,34 +559,33 @@ mod tests_kzg_impl {
         );
         assert!(res.is_err());
 
-        let (value, proof) = pcs
-            .prove_eval(&mut not_needed_transcript, &opening, &point, max_degree)
+        let proof = pcs
+            .prove(&mut not_needed_transcript, &opening, &point, max_degree)
             .unwrap();
-        assert_eq!(value, seven);
 
-        let res = pcs.verify_eval(
+        let res = pcs.verify(
             &mut not_needed_transcript,
             &commitment_value,
             degree,
             &point,
-            &value,
+            &seven,
             &proof,
         );
         pnk!(res);
 
         let new_pcs = pcs.shrink_to_verifier_only().unwrap();
-        let res = new_pcs.verify_eval(
+        let res = new_pcs.verify(
             &mut not_needed_transcript,
             &commitment_value,
             degree,
             &point,
-            &value,
+            &seven,
             &proof,
         );
         pnk!(res);
 
         let wrong_value_verif = one;
-        let wrong_value_verif = pcs.verify_eval(
+        let wrong_value_verif = pcs.verify(
             &mut not_needed_transcript,
             &commitment_value,
             degree,

--- a/plonk/src/poly_commit/pcs.rs
+++ b/plonk/src/poly_commit/pcs.rs
@@ -45,7 +45,7 @@ pub trait HomomorphicPolyComElem: ToBytes + Clone {
 /// Trait for polynomial commitment scheme.
 pub trait PolyComScheme: Sized {
     /// Type of prime field.
-    type Field: Scalar;
+    type Field: Scalar + Debug;
 
     /// Type of commitment produces, need to implement `HomomorphicPolyComElem`.
     type Commitment: HomomorphicPolyComElem<Scalar = Self::Field>
@@ -138,6 +138,7 @@ pub trait PolyComScheme: Sized {
         for open in openings.iter() {
             let mut poly = self.polynomial_from_opening_ref(open);
             let eval_value = poly.eval(point);
+            println!("eval_value = {:?}", eval_value);
             poly.sub_assign(&FpPolynomial::from_coefs(vec![eval_value]));
             poly.mul_scalar_assign(&c_i);
             h.add_assign(&poly);

--- a/plonk/src/poly_commit/pcs.rs
+++ b/plonk/src/poly_commit/pcs.rs
@@ -12,7 +12,7 @@ pub trait ToBytes {
 }
 
 /// The trait for homomorphic polynomial commitment field.
-pub trait HomomorphicPolyComElem: ToBytes {
+pub trait HomomorphicPolyComElem: ToBytes + Clone {
     /// This is the scalar field of the polynomial.
     type Scalar;
 
@@ -23,44 +23,24 @@ pub trait HomomorphicPolyComElem: ToBytes {
     fn get_identity() -> Self;
 
     /// Add the underlying polynomials.
-    fn op(&self, other: &Self) -> Self;
+    fn add(&self, other: &Self) -> Self;
 
     /// Add assign the underlying polynomials.
-    fn op_assign(&mut self, other: &Self);
+    fn add_assign(&mut self, other: &Self);
+
+    /// Subtract the underlying polynomials.
+    fn sub(&self, other: &Self) -> Self;
+
+    /// Subtract assign the underlying polynomials.
+    fn sub_assign(&mut self, other: &Self);
 
     /// Multiply underlying polynomial by scalar `exp` represented
     /// in least significant byte first.
-    fn exp(&self, exp: &Self::Scalar) -> Self;
+    fn mul(&self, exp: &Self::Scalar) -> Self;
 
     /// Multiply underlying polynomial by scalar `exp`.
-    fn exp_assign(&mut self, exp: &Self::Scalar);
-
-    /// Negate the polynomials coefficients.
-    fn inv(&self) -> Self;
+    fn mul_assign(&mut self, exp: &Self::Scalar);
 }
-
-/// Batch eval proof of polynomial.
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Clone)]
-pub struct BatchProofEval<C, E> {
-    /// The commitment of batch eval.
-    commitment: C,
-    /// The eval proof.
-    eval_proof: E,
-}
-
-/// Batch eval params of polynomial.
-pub struct BatchEvalParams<'a, C, F> {
-    commitments: &'a [&'a C],
-    evals: &'a [F],
-}
-
-/// Define the batch eval proof by given `PolyComScheme`.
-pub type BatchPfEval<PCS> =
-    BatchProofEval<<PCS as PolyComScheme>::Commitment, <PCS as PolyComScheme>::EvalProof>;
-
-/// Define the Option type of batch eval params by given `PolyComScheme`.
-pub type OptionParams<'a, PCS> =
-    Option<BatchEvalParams<'a, <PCS as PolyComScheme>::Commitment, <PCS as PolyComScheme>::Field>>;
 
 /// Trait for polynomial commitment scheme.
 pub trait PolyComScheme: Sized {
@@ -75,9 +55,6 @@ pub trait PolyComScheme: Sized {
         + Clone
         + Serialize
         + for<'de> Deserialize<'de>;
-
-    /// Type of `EvalProof`.
-    type EvalProof: ToBytes + Serialize + for<'de> Deserialize<'de> + Debug + PartialEq + Eq;
 
     /// Type of `Opening`.
     type Opening: HomomorphicPolyComElem<Scalar = Self::Field> + Debug + PartialEq + Eq + Clone;
@@ -107,24 +84,24 @@ pub trait PolyComScheme: Sized {
     fn polynomial_from_opening(&self, opening: Self::Opening) -> FpPolynomial<Self::Field>;
 
     /// Evaluate the polynomial producing a proof for it.
-    fn prove_eval(
+    fn prove(
         &self,
         transcript: &mut Transcript,
         opening: &Self::Opening,
         point: &Self::Field,
         max_degree: usize,
-    ) -> Result<(Self::Field, Self::EvalProof)>;
+    ) -> Result<Self::Commitment>;
 
     /// Verify an evaluation proof that polynomial inside commitment
     /// evaluates to `value` on input `point `.
-    fn verify_eval(
+    fn verify(
         &self,
         transcript: &mut Transcript,
         commitment: &Self::Commitment,
         degree: usize,
         point: &Self::Field,
         value: &Self::Field,
-        proof: &Self::EvalProof,
+        proof: &Self::Commitment,
     ) -> Result<()>;
 
     /// Apply blind factors over the vanishing part
@@ -139,42 +116,32 @@ pub trait PolyComScheme: Sized {
     /// `param` stores the instance parameters to be appended to the transcript.
     /// When `param` is `None`, our function assumes `params` are implicit
     /// in the transcript already.
-    fn batch_prove_eval(
+    fn batch_prove(
         &self,
         transcript: &mut Transcript,
         openings: &[&Self::Opening],
-        points: &[Self::Field],
+        point: &Self::Field,
         max_degree: usize,
-        params: OptionParams<'_, Self>,
-    ) -> Result<(Vec<Self::Field>, BatchPfEval<Self>)> {
+    ) -> Result<Self::Commitment> {
         let n = openings.len();
-        assert_eq!(n, points.len());
         assert!(n > 0);
 
-        Self::init_pcs_batch_eval_transcript(transcript, max_degree, points, params);
+        Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
 
         // 1. Compute quotient Polynomial q(X) = h(X)/z(X), where
-        // h(X) = \sum_i \alpha^i * z_i_bar(X) * [fi(X) - fi(xi)]
-
-        // linear combination scalar factor
+        // h(X) = \sum_i \alpha^i * [fi(X) - fi(xi)]
         let alpha = transcript.get_challenge_field_elem(b"alpha");
         let mut h = FpPolynomial::<Self::Field>::zero();
         let mut c_i = Self::Field::one(); // linear combination first scalar = alpha^0
-        let z = FpPolynomial::from_zeroes(points);
-        let mut eval_values = vec![];
-        let mut z_i_bar_vec = vec![];
-        for (open, point) in openings.iter().zip(points) {
+        let z = FpPolynomial::from_zeroes(&[point.clone()]);
+
+        for open in openings.iter() {
             let mut poly = self.polynomial_from_opening_ref(open);
             let eval_value = poly.eval(point);
-            eval_values.push(eval_value);
             poly.sub_assign(&FpPolynomial::from_coefs(vec![eval_value]));
             poly.mul_scalar_assign(&c_i);
-            let z_i = FpPolynomial::from_zeroes(&[*point]);
-            let (z_i_bar, _) = z.div_rem(&z_i);
-            h.add_assign(&poly.fast_mul(&z_i_bar));
-
+            h.add_assign(&poly);
             c_i.mul_assign(&alpha);
-            z_i_bar_vec.push(z_i_bar);
         }
 
         let (q, rem) = h.div_rem(&z);
@@ -182,118 +149,48 @@ pub trait PolyComScheme: Sized {
             return Err(eg!());
         }
 
-        let (c_q, o_q) = self.commit(q).c(d!())?;
-        transcript.append_commitment::<Self::Commitment>(&c_q);
-
-        // Derive opening of g(X)
-        // = sum \alpha^i * z_i_bar(\rho) * (fi(X) - fi(xi)) - q(X) * z(rho)
-        // = - z(rho) * q(X)
-        //   + sum \alpha^i * z_i_bar(\rho) * fi(X)
-        //   - [sum \alpha^i * z_i_bar(\rho) * fi(xi)]
-        let rho = transcript.get_challenge_field_elem(b"rho");
-
-        // term `-z(rho) * q(X)`
-        let mut g_opening = o_q.inv();
-        let z_eval_rho = z.eval(&rho);
-        g_opening = g_opening.exp(&z_eval_rho);
-
-        // term `\sum \alpha^i * z_i_bar(\rho) * fi(X)`
-        let mut c_i = Self::Field::one(); // alpha^i
-        let mut val_sum = Self::Field::zero(); // val_sum = sum f_i(x_i) * alpha^i * z_i_bar(\rho)
-        for ((z_i_bar, opening_i), value) in z_i_bar_vec
-            .iter()
-            .zip(openings.iter())
-            .zip(eval_values.iter())
-        {
-            let mut poly_i = (*(*opening_i)).clone();
-            let zi_bar_eval_rho = z_i_bar.eval(&rho);
-            let scalar = zi_bar_eval_rho.mul(&c_i);
-            poly_i = poly_i.exp(&scalar);
-            g_opening = g_opening.op(&poly_i);
-            let value_times_scalar = value.mul(&scalar);
-            val_sum.add_assign(&value_times_scalar);
-            c_i.mul_assign(&alpha);
-        }
-
-        // term `-[sum \alpha^i * z_i_bar(\rho) * fi(xi)]`
-        let poly_values_sum_opening = self.opening(&FpPolynomial::from_coefs(vec![val_sum]));
-        g_opening = g_opening.op(&poly_values_sum_opening.inv());
-
-        let (g_value, g_proof) = self
-            .prove_eval(transcript, &g_opening, &rho, max_degree)
-            .c(d!())?;
-        if !g_value.is_zero() {
-            Err(eg!())
-        } else {
-            Ok((
-                eval_values,
-                BatchProofEval {
-                    commitment: c_q,
-                    eval_proof: g_proof,
-                },
-            ))
-        }
+        let (c_q, _) = self.commit(q).c(d!())?;
+        Ok(c_q)
     }
 
-    /// Verify batch eval proof.
-    /// Optimized according to Sec 4.1 in <https://eprint.iacr.org/2020/081.pdf>
-    /// Saves |points| G1 exps
-    fn batch_verify_eval(
+    /// Verify a batched proof
+    fn batch_verify(
         &self,
         transcript: &mut Transcript,
         commitments: &[&Self::Commitment],
         max_degree: usize,
-        points: &[Self::Field],
+        point: &Self::Field,
         values: &[Self::Field],
-        proof: &BatchPfEval<Self>,
-        params: OptionParams<'_, Self>,
+        proof: &Self::Commitment,
     ) -> Result<()> {
-        Self::init_pcs_batch_eval_transcript(transcript, max_degree, points, params);
+        Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
         let alpha = transcript.get_challenge_field_elem::<Self::Field>(b"alpha");
-        transcript.append_commitment::<Self::Commitment>(&proof.commitment);
-        let rho = transcript.get_challenge_field_elem::<Self::Field>(b"rho");
-
-        // 1. z_eval_rho = prod (X - point_i) at X = \rho
-        let mut z_eval_rho = Self::Field::one();
-        for point in points {
-            let aux = rho.sub(point);
-            z_eval_rho.mul_assign(&aux)
-        }
 
         // Compute commitment F = com_lc - Com(q(X) * z(\rho)), where
         // com_lc = sum_i alpha^i * z_i_bar(\rho)) * Com((f_i(X) - y_i)
         //        = sum_i alpha^i * z_i_bar(\rho)) * Com(f_i(X))
         //          - Com(sum_i alpha^i * z_i_bar(\rho)) * y_i)
-        let mut c_i = Self::Field::one(); // linear combination scalar c_i = alpha^i
+        let mut c_i = Self::Field::one();
         let mut com_lc = Self::Commitment::get_identity();
-        let mut val_lc = Self::Field::zero(); // \sum y_i * alpha^i * \z_i_bar(rho)
-        for ((point, value), commitment) in points.iter().zip(values).zip(commitments) {
-            let rho_minus_point_inv = rho.sub(point).inv().c(d!())?;
-            let z_i_bar_eval_rho = z_eval_rho.mul(&rho_minus_point_inv);
-
-            let scalar = z_i_bar_eval_rho.mul(&c_i);
-
-            com_lc = com_lc.op(&commitment.exp(&scalar));
-
-            let value_times_scalar = scalar.mul(value);
+        let mut val_lc = Self::Field::zero();
+        for (value, commitment) in values.iter().zip(commitments) {
+            com_lc = com_lc.add(&commitment.mul(&c_i));
+            let value_times_scalar = c_i.mul(value);
             val_lc.add_assign(&value_times_scalar);
-
             c_i.mul_assign(&alpha);
         }
         let (com, _) = self
             .commit(FpPolynomial::from_coefs(vec![val_lc]))
             .c(d!())?;
-        com_lc = com_lc.op(&com.inv());
-        // - Com(q(X) * z(\rho))
-        let com_z_q = proof.commitment.exp(&z_eval_rho);
-        let derived_commitment = com_lc.op(&com_z_q.inv());
-        self.verify_eval(
+        com_lc = com_lc.sub(&com);
+
+        self.verify(
             transcript,
-            &derived_commitment,
+            &com_lc,
             max_degree,
-            &rho,
+            &point,
             &Self::Field::zero(),
-            &proof.eval_proof,
+            &proof,
         )
         .c(d!())
     }
@@ -302,33 +199,21 @@ pub trait PolyComScheme: Sized {
     fn init_pcs_batch_eval_transcript(
         transcript: &mut Transcript,
         max_degree: usize,
-        points: &[Self::Field],
-        params: Option<BatchEvalParams<'_, Self::Commitment, Self::Field>>,
+        point: &Self::Field,
     ) {
         transcript.append_message(b"Domain Separator", b"New PCS-Batch-Eval Protocol");
-        Self::transcript_append_params(transcript, max_degree, points, params);
+        Self::transcript_append_params(transcript, max_degree, point);
     }
 
     /// Append params to the transaction.
     fn transcript_append_params(
         transcript: &mut Transcript,
         max_degree: usize,
-        points: &[Self::Field],
-        params: Option<BatchEvalParams<'_, Self::Commitment, Self::Field>>,
+        point: &Self::Field,
     ) {
         transcript.append_message(b"field size", &Self::Field::get_field_size_le_bytes());
         transcript.append_u64(b"max_degree", max_degree as u64);
-        for point in points.iter() {
-            transcript.append_field_elem(point);
-        }
-        if let Some(pcs_params) = params {
-            for commitment in pcs_params.commitments.iter() {
-                transcript.append_commitment::<Self::Commitment>(commitment);
-            }
-            for value in pcs_params.evals.iter() {
-                transcript.append_field_elem(value);
-            }
-        }
+        transcript.append_field_elem(point);
     }
 
     /// Shrink this to only for verifier use.
@@ -384,9 +269,7 @@ pub trait ShiftPCS: PolyComScheme {
 #[allow(non_snake_case)]
 mod test {
     use crate::poly_commit::{
-        field_polynomial::FpPolynomial,
-        kzg_poly_com::KZGCommitmentScheme,
-        pcs::{BatchEvalParams, PolyComScheme},
+        field_polynomial::FpPolynomial, kzg_poly_com::KZGCommitmentScheme, pcs::PolyComScheme,
     };
     use merlin::Transcript;
     use rand_chacha::ChaChaRng;
@@ -404,16 +287,15 @@ mod test {
         let pcs = KZGCommitmentScheme::new(degree, &mut prng);
         let (com, open) = pcs.commit(poly).unwrap();
         let point = BLSScalar::random(&mut prng);
-        let (eval, proof) = {
+        let proof = {
             let mut transcript = Transcript::new(b"TestPCS");
-            pcs.prove_eval(&mut transcript, &open, &point, degree)
-                .unwrap()
+            pcs.prove(&mut transcript, &open, &point, degree).unwrap()
         };
-        assert_eq!(eval, pcs.eval_opening(&open, &point));
+        let eval = pcs.eval_opening(&open, &point);
         {
             let mut transcript = Transcript::new(b"TestPCS");
             assert!(pcs
-                .verify_eval(&mut transcript, &com, degree, &point, &eval, &proof)
+                .verify(&mut transcript, &com, degree, &point, &eval, &proof)
                 .is_ok());
         }
     }
@@ -434,125 +316,27 @@ mod test {
         let (com1, open1) = pcs.commit(poly1).unwrap();
         let (com2, open2) = pcs.commit(poly2).unwrap();
         let (com3, open3) = pcs.commit(poly3).unwrap();
-        let point1 = Field::random(&mut prng);
-        let point2 = Field::random(&mut prng);
-        let point3 = Field::random(&mut prng);
-        let points = [point1, point2, point3];
-        let (evals, proof) = {
+        let point = Field::random(&mut prng);
+        let proof = {
             let mut transcript = Transcript::new(b"TestPCS");
-            let params = BatchEvalParams {
-                commitments: &[&com1, &com2, &com3],
-                evals: &[],
-            };
-            pcs.batch_prove_eval(
-                &mut transcript,
-                &[&open1, &open2, &open3],
-                &points,
-                degree,
-                Some(params),
-            )
-            .unwrap()
+            pcs.batch_prove(&mut transcript, &[&open1, &open2, &open3], &point, degree)
+                .unwrap()
         };
-        assert_eq!(
-            evals,
-            vec![
-                pcs.eval_opening(&open1, &points[0]),
-                pcs.eval_opening(&open2, &points[1]),
-                pcs.eval_opening(&open3, &points[2])
-            ]
-        );
+        let evals = vec![
+            pcs.eval_opening(&open1, &point),
+            pcs.eval_opening(&open2, &point),
+            pcs.eval_opening(&open3, &point),
+        ];
         {
             let mut transcript = Transcript::new(b"TestPCS");
-            let params = BatchEvalParams {
-                commitments: &[&com1, &com2, &com3],
-                evals: &[],
-            };
             assert!(pcs
-                .batch_verify_eval(
+                .batch_verify(
                     &mut transcript,
                     &[&com1, &com2, &com3],
                     degree,
-                    &points,
+                    &point,
                     &evals,
                     &proof,
-                    Some(params)
-                )
-                .is_ok());
-        }
-    }
-
-    #[test]
-    fn test_pcs_batch_eval_simulate_plonk() {
-        let mut prng = ChaChaRng::from_seed([0u8; 32]);
-        type Field = BLSScalar;
-        let degree = 16;
-        let pcs = KZGCommitmentScheme::new(degree + 1, &mut prng);
-        let zero = Field::zero();
-        let one = Field::one();
-        let two = one.add(&one);
-        let three = two.add(&one);
-
-        let f1 = FpPolynomial::from_coefs(vec![zero, one, two, two, two, one]);
-        let f2 = FpPolynomial::from_coefs(vec![one, zero, three, two, two, one]);
-        let f3 = FpPolynomial::from_coefs(vec![two, two, two, two, two, two]);
-        let perm1 = FpPolynomial::from_coefs(vec![two, two, two, two]);
-        let perm2 = FpPolynomial::from_coefs(vec![two, two, two, two]);
-        let Q = FpPolynomial::from_coefs(vec![two; 17]);
-        let L = FpPolynomial::from_coefs(vec![two; 6]);
-        let Sigma = FpPolynomial::from_coefs(vec![one; 6]);
-
-        let g = two;
-        let beta = Field::random(&mut prng);
-        let beta_sq = beta.mul(&beta);
-        let beta_g = beta.mul(&g);
-
-        let (comf1, openf1) = pcs.commit(f1).unwrap();
-        let (comf2, openf2) = pcs.commit(f2).unwrap();
-        let (comf3, openf3) = pcs.commit(f3).unwrap();
-        let (comperm1, openperm1) = pcs.commit(perm1).unwrap();
-        let (comperm2, openperm2) = pcs.commit(perm2).unwrap();
-        let (comQ, openQ) = pcs.commit(Q).unwrap();
-        let (comL, openL) = pcs.commit(L).unwrap();
-        let (comSigma, openSigma) = pcs.commit(Sigma).unwrap();
-        let points = [beta, beta_sq, beta, beta, beta, beta, beta, beta_g];
-        let (evals, proof) = {
-            let mut transcript = Transcript::new(b"TestPCS");
-            pcs.batch_prove_eval(
-                &mut transcript,
-                //&[&f1, &f2, &f3, &perm1, &perm2, &Q, &L, &Sigma],
-                &[
-                    &openf1, &openf2, &openf3, &openperm1, &openperm2, &openQ, &openL, &openSigma,
-                ],
-                &points,
-                degree,
-                None,
-            )
-            .unwrap()
-        };
-        assert_eq!(
-            evals,
-            vec![
-                pcs.eval_opening(&openf1, &points[0]),
-                pcs.eval_opening(&openf2, &points[1]),
-                pcs.eval_opening(&openf3, &points[2]),
-                pcs.eval_opening(&openperm1, &points[3]),
-                pcs.eval_opening(&openperm2, &points[4]),
-                pcs.eval_opening(&openQ, &points[5]),
-                pcs.eval_opening(&openL, &points[6]),
-                pcs.eval_opening(&openSigma, &points[7])
-            ]
-        );
-        {
-            let mut transcript = Transcript::new(b"TestPCS");
-            assert!(pcs
-                .batch_verify_eval(
-                    &mut transcript,
-                    &[&comf1, &comf2, &comf3, &comperm1, &comperm2, &comQ, &comL, &comSigma],
-                    degree, //Q.degree()
-                    &points,
-                    &evals,
-                    &proof,
-                    None
                 )
                 .is_ok());
         }

--- a/plonk/src/poly_commit/pcs.rs
+++ b/plonk/src/poly_commit/pcs.rs
@@ -126,7 +126,7 @@ pub trait PolyComScheme: Sized {
         let n = openings.len();
         assert!(n > 0);
 
-        //Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
+        Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
 
         // 1. Compute quotient Polynomial q(X) = h(X)/z(X), where
         // h(X) = \sum_i \alpha^i * [fi(X) - fi(xi)]
@@ -143,8 +143,6 @@ pub trait PolyComScheme: Sized {
             h.add_assign(&poly);
             c_i.mul_assign(&alpha);
         }
-
-        println!("alpha = {:?}", alpha);
 
         let (q, rem) = h.div_rem(&z);
         if !rem.is_zero() {
@@ -164,10 +162,8 @@ pub trait PolyComScheme: Sized {
         point: &Self::Field,
         values: &[Self::Field],
     ) -> (Self::Commitment, Self::Field) {
-        //Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
+        Self::init_pcs_batch_eval_transcript(transcript, max_degree, point);
         let alpha = transcript.get_challenge_field_elem::<Self::Field>(b"alpha");
-
-        println!("alpha = {:?}", alpha.clone());
 
         // Compute commitment F = com_lc - Com(q(X) * z(\rho)), where
         // com_lc = sum_i alpha^i * z_i_bar(\rho)) * Com((f_i(X) - y_i)

--- a/plonk/src/poly_commit/transcript.rs
+++ b/plonk/src/poly_commit/transcript.rs
@@ -1,4 +1,4 @@
-use crate::poly_commit::pcs::{PolyComScheme, ToBytes};
+use crate::poly_commit::pcs::ToBytes;
 use merlin::Transcript;
 use zei_algebra::prelude::*;
 
@@ -9,9 +9,6 @@ pub trait PolyComTranscript {
 
     /// Append the field to the transcript.
     fn append_field_elem<F: Scalar>(&mut self, point: &F);
-
-    /// Append the eval proof to the transaction.
-    fn append_eval_proof<PCS: PolyComScheme>(&mut self, proof: &PCS::EvalProof);
 
     /// Get challenge result.
     fn get_challenge_field_elem<F: Scalar>(&mut self, label: &'static [u8]) -> F;
@@ -24,10 +21,6 @@ impl PolyComTranscript for Transcript {
 
     fn append_field_elem<F: Scalar>(&mut self, field_elem: &F) {
         self.append_message(b"append field point", &field_elem.to_bytes());
-    }
-
-    fn append_eval_proof<PCS: PolyComScheme>(&mut self, proof: &PCS::EvalProof) {
-        self.append_message(b"append eval proof", &proof.to_bytes());
     }
 
     fn get_challenge_field_elem<F: Scalar>(&mut self, label: &'static [u8]) -> F {


### PR DESCRIPTION
This PR makes changes to the TurboPlonk implementation, as follows. Note that this construction is now materially different from the prior construction and the textbook Plonk.

First of all, adopting an optimization in the later version of the Plonk paper, we remove \bar{t} and \bar{r} from the proof. This reduces the proof size by two field elements. 

Second, we simplify the polynomial commitment since we only open in two points, and existing multi-point commitment scheme is not better in this case. 

Third, adopting an optimization in the later version of the Plonk paper, which uses the split polynomial in the computation of the linearization polynomial.

Fourth, still from the Plonk paper, we merge the two pairing equations into one. 