### PR TITLE
Apply the latest Plonk update

### DIFF
--- a/plonk/src/plonk/prover.rs
+++ b/plonk/src/plonk/prover.rs
@@ -213,7 +213,7 @@ pub fn prover_with_lagrange<
     let t_poly =
         t_poly::<PCS, CS>(cs, prover_params, &w_polys, &z_poly, &challenges, &pi).c(d!())?;
     let (cm_t_vec, t_polys) =
-        split_t_and_commit(pcs, &t_poly, n_wires_per_gate, n_constraints + 2).c(d!())?;
+        split_t_and_commit(prng, pcs, &t_poly, n_wires_per_gate, n_constraints + 2).c(d!())?;
 
     for cm_t in cm_t_vec.iter() {
         transcript.append_commitment::<PCS::Commitment>(cm_t);


### PR DESCRIPTION
Previously, the t polynomial in Plonk (as well as the split t polynomials) is not randomized. Although these polynomials are never opened directly (instead, only the r polynomial is opened), the commitments themselves may reveal information. 

https://twitter.com/rel_Aztec/status/1542474208982478849

Though in practice it is not easy to break the zero-knowledge property in Plonk by looking at these commitments, and indeed, the attacker's ability may be limited to distinguishing between different witnesses, it would be easier if we make this change right now instead of doing it later.

This PR, therefore, adds the randomizers according to the new Plonk paper. This is not a breaking change, as old commitments can be considered the case with zero randomizers, and new commitments can also be verified by the old verifier. Indeed, the code of the verifier remains the same.