### PR TITLE
Add tx-level non malleability

### DIFF
--- a/accumulators/Cargo.toml
+++ b/accumulators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'zei-accumulators'
-version = '0.1.0'
+version = '0.2.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 description = 'Zei accumulators commons'

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -6,7 +6,7 @@ harness = false
 [package]
 name = 'zei-algebra'
 description = 'Zei algebra library'
-version = '0.1.4'
+version = '0.2.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,7 +5,7 @@ required-features = ['gen']
 
 [package]
 name = 'zei'
-version = '0.1.4'
+version = '0.2.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 description = 'Zei Platform Interface'

--- a/api/src/anon_xfr/abar_to_abar.rs
+++ b/api/src/anon_xfr/abar_to_abar.rs
@@ -46,6 +46,17 @@ pub struct AXfrNote {
     pub non_malleability_tag: BLSScalar,
 }
 
+/// Anonymous transfer pre-note without proof and non-malleability tag.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clond, Eq)]
+pub struct AXfrPreNote<'a> {
+    /// The anonymous transfer body.
+    pub body: AXfrBody,
+    /// The reference to the prover parameters.
+    pub params: &'a ProverParams,
+    /// Witness.
+    pub witness: AXfrWitness,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Eq)]
 /// Anonymous transfer body.
 pub struct AXfrBody {
@@ -64,6 +75,13 @@ pub struct AXfrBody {
 }
 
 /// Build an anonymous transfer note.
+#[deprecated(
+    since = "0.2",
+    note = "For transaction-level non-malleability instead of \
+operation-level non-malleability, the note requires a two-step building process consisting of \
+`init_anon_transfer_note` which generates `AXfrPreNote` and `finish_anon_transfer_note` which \
+generates `AXfrPreNote` given the transaction-level hash."
+)]
 pub fn gen_anon_xfr_note<R: CryptoRng + RngCore>(
     prng: &mut R,
     params: &ProverParams,
@@ -80,7 +98,7 @@ pub fn gen_anon_xfr_note<R: CryptoRng + RngCore>(
     check_asset_amount(inputs, outputs, fee).c(d!())?;
     check_roots(inputs).c(d!())?;
 
-    // 2. build input witness infos
+    // 2. build input witness information
     let nullifiers = inputs
         .iter()
         .zip(input_keypairs.iter())
@@ -165,6 +183,118 @@ pub fn gen_anon_xfr_note<R: CryptoRng + RngCore>(
         non_malleability_tag,
     })
 }
+
+pub fn init_anon_xfr_note<'a, R: CryptoRng + RngCore>(
+    prng: &mut R,
+    params: &'a ProverParams,
+    inputs: &[OpenAnonAssetRecord],
+    outputs: &[OpenAnonAssetRecord],
+    fee: u32,
+    input_keypairs: &[AXfrKeyPair],
+) -> Result<AXfrPreNote<'a>> {
+    // 1. check input correctness
+    if inputs.is_empty() || outputs.is_empty() {
+        return Err(eg!(ZeiError::AXfrProverParamsError));
+    }
+    check_inputs(inputs, input_keypairs).c(d!())?;
+    check_asset_amount(inputs, outputs, fee).c(d!())?;
+    check_roots(inputs).c(d!())?;
+
+    // 2. build input witness information
+    let nullifiers = inputs
+        .iter()
+        .zip(input_keypairs.iter())
+        .map(|(input, keypair)| {
+            let mt_leaf_info = input.mt_leaf_info.as_ref().unwrap();
+            nullify_with_native_address(&keypair, input.amount, &input.asset_type, mt_leaf_info.uid)
+        })
+        .collect();
+
+    // 3. build proof
+    let payers_secrets = inputs
+        .iter()
+        .zip(input_keypairs.iter())
+        .map(|(input, keypair)| {
+            let mt_leaf_info = input.mt_leaf_info.as_ref().unwrap();
+            PayerWitness {
+                spend_key: keypair.get_spend_key_scalar(),
+                uid: mt_leaf_info.uid,
+                amount: input.amount,
+                asset_type: input.asset_type.as_scalar(),
+                path: mt_leaf_info.path.clone(),
+                blind: input.blind,
+            }
+        })
+        .collect();
+    let payees_secrets = outputs
+        .iter()
+        .map(|output| PayeeWitness {
+            amount: output.amount,
+            blind: output.blind,
+            asset_type: output.asset_type.as_scalar(),
+            pubkey_x: output.pub_key.0.get_x(),
+        })
+        .collect();
+
+    let secret_inputs = AXfrWitness {
+        payers_witnesses: payers_secrets,
+        payees_witnesses: payees_secrets,
+        fee,
+    };
+    let out_abars = outputs
+        .iter()
+        .map(AnonAssetRecord::from_oabar)
+        .collect_vec();
+    let out_memos: Result<Vec<AxfrOwnerMemo>> = outputs
+        .iter()
+        .map(|output| output.owner_memo.clone().c(d!(ZeiError::ParameterError)))
+        .collect();
+
+    let mt_info_temp = inputs[0].mt_leaf_info.as_ref().unwrap();
+    let body = AXfrBody {
+        inputs: nullifiers,
+        outputs: out_abars,
+        merkle_root: mt_info_temp.root,
+        merkle_root_version: mt_info_temp.root_version,
+        fee,
+        owner_memos: out_memos.c(d!())?,
+    };
+
+    Ok(AXfrPreNote {
+        body,
+        params,
+        witness: secret_inputs,
+    })
+}
+
+/*
+
+
+   let msg = bincode::serialize(&body)
+       .c(d!(ZeiError::SerializationError))
+       .c(d!())?;
+
+   let input_keypairs_ref: Vec<&AXfrKeyPair> = input_keypairs.iter().collect();
+
+   let (hash, non_malleability_randomizer, non_malleability_tag) =
+       compute_non_malleability_tag(prng, b"AnonXfr", &msg, &input_keypairs_ref);
+
+   let proof = prove_xfr(
+       prng,
+       params,
+       secret_inputs,
+       &hash,
+       &non_malleability_randomizer,
+       &non_malleability_tag,
+   )
+       .c(d!())?;
+
+   Ok(AXfrNote {
+       body,
+       anon_xfr_proof: proof,
+       non_malleability_tag,
+   })
+*/
 
 /// Verify an anonymous transfer note.
 pub fn verify_anon_xfr_note(

--- a/api/src/anon_xfr/abar_to_ar.rs
+++ b/api/src/anon_xfr/abar_to_ar.rs
@@ -1,7 +1,7 @@
-use crate::anon_xfr::abar_to_abar::{add_payers_witnesses, AXfrPreNote};
-use crate::anon_xfr::keys::{get_view_key_domain_separator, AXfrKeyPair};
 use crate::anon_xfr::{
+    abar_to_abar::add_payers_witnesses,
     commit_in_cs_with_native_address, compute_merkle_root_variables, compute_non_malleability_tag,
+    keys::{get_view_key_domain_separator, AXfrKeyPair},
     nullify_in_cs_with_native_address, nullify_with_native_address,
     structs::{AccElemVars, Nullifier, NullifierInputVars, OpenAnonAssetRecord, PayerWitness},
     AXfrPlonkPf, TurboPlonkCS, SK_LEN,
@@ -14,9 +14,8 @@ use crate::xfr::{
     sig::XfrPublicKey,
     structs::{AssetRecordTemplate, BlindAssetRecord, OwnerMemo},
 };
-use digest::Digest;
+use digest::{consts::U64, Digest};
 use merlin::Transcript;
-use sha2::Sha512;
 use zei_algebra::{bls12_381::BLSScalar, jubjub::JubjubPoint, prelude::*};
 use zei_crypto::basic::ristretto_pedersen_comm::RistrettoPedersenCommitment;
 use zei_plonk::plonk::{
@@ -39,7 +38,7 @@ pub struct AbarToArNote {
 }
 
 /// The anonymous-to-transparent note without proof or non-malleability tag.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug)]
 pub struct AbarToArPreNote {
     /// The body part of ABAR to AR.
     pub body: AbarToArBody,
@@ -64,8 +63,9 @@ pub struct AbarToArBody {
     pub memo: Option<OwnerMemo>,
 }
 
-/// Generate an anonymous-to-transparent note.
-pub fn init_abar_to_ar_note(
+/// Generate an anonymous-to-transparent pre-note.
+pub fn init_abar_to_ar_note<R: CryptoRng + RngCore>(
+    prng: &mut R,
     oabar: &OpenAnonAssetRecord,
     abar_keypair: &AXfrKeyPair,
     ar_pub_key: &XfrPublicKey,
@@ -116,7 +116,7 @@ pub fn init_abar_to_ar_note(
     Ok(AbarToArPreNote {
         body,
         witness: payers_secret,
-        input_keypair: AXfrKeyPair,
+        input_keypair: abar_keypair.clone(),
     })
 }
 
@@ -125,7 +125,7 @@ pub fn finish_abar_to_ar_note<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
     prng: &mut R,
     params: &ProverParams,
     pre_note: AbarToArPreNote,
-    hash: &D,
+    hash: D,
 ) -> Result<AbarToArNote> {
     let AbarToArPreNote {
         body,
@@ -133,14 +133,16 @@ pub fn finish_abar_to_ar_note<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
         input_keypair,
     } = pre_note;
 
+    let hash_scalar = BLSScalar::from_hash::<D>(hash);
+
     let (non_malleability_randomizer, non_malleability_tag) =
-        compute_non_malleability_tag(prng, hash, &[&input_keypair]);
+        compute_non_malleability_tag(prng, hash_scalar, &[&input_keypair]);
 
     let proof = prove_abar_to_ar(
         prng,
         params,
         witness,
-        &hash,
+        &hash_scalar,
         &non_malleability_randomizer,
         &non_malleability_tag,
     )
@@ -154,10 +156,11 @@ pub fn finish_abar_to_ar_note<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
 }
 
 /// Verify the anonymous-to-transparent note.
-pub fn verify_abar_to_ar_note(
+pub fn verify_abar_to_ar_note<D: Digest<OutputSize = U64> + Default>(
     params: &VerifierParams,
     note: &AbarToArNote,
     merkle_root: &BLSScalar,
+    hash: D,
 ) -> Result<()> {
     // require the output amount & asset type are non-confidential
     if note.body.output.amount.is_confidential() || note.body.output.asset_type.is_confidential() {
@@ -171,13 +174,7 @@ pub fn verify_abar_to_ar_note(
         return Err(eg!(ZeiError::AXfrVerificationError));
     }
 
-    let msg = bincode::serialize(&note.body)
-        .c(d!(ZeiError::SerializationError))
-        .c(d!())?;
-    let mut hasher = Sha512::new();
-    hasher.update(b"AbarToAr");
-    hasher.update(msg.as_slice());
-    let hash = BLSScalar::from_hash(hasher);
+    let hash_scalar = BLSScalar::from_hash::<D>(hash);
 
     let mut transcript = Transcript::new(ABAR_TO_AR_TRANSCRIPT);
     let mut online_inputs = vec![];
@@ -185,7 +182,7 @@ pub fn verify_abar_to_ar_note(
     online_inputs.push(merkle_root.clone());
     online_inputs.push(BLSScalar::from(payer_amount));
     online_inputs.push(payer_asset_type.as_scalar());
-    online_inputs.push(hash);
+    online_inputs.push(hash_scalar);
     online_inputs.push(note.non_malleability_tag);
 
     verifier(
@@ -346,15 +343,17 @@ pub fn build_abar_to_ar_cs(
 mod tests {
     use crate::anon_xfr::keys::AXfrKeyPair;
     use crate::anon_xfr::{
-        abar_to_ar::{gen_abar_to_ar_note, verify_abar_to_ar_note},
+        abar_to_ar::{finish_abar_to_ar_note, init_abar_to_ar_note, verify_abar_to_ar_note},
         structs::{AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecordBuilder},
         TREE_DEPTH,
     };
     use crate::setup::{ProverParams, VerifierParams};
     use crate::xfr::{sig::XfrKeyPair, structs::AssetType};
+    use digest::Digest;
     use mem_db::MemoryDB;
     use parking_lot::RwLock;
     use rand_chacha::ChaChaRng;
+    use sha2::Sha512;
     use std::sync::Arc;
     use storage::{
         state::{ChainState, State},
@@ -398,19 +397,49 @@ mod tests {
 
         oabar.update_mt_leaf_info(build_mt_leaf_info_from_proof(proof.clone()));
 
-        let note = gen_abar_to_ar_note(&mut prng, &params, &oabar.clone(), &sender, &recv.pub_key)
-            .unwrap();
+        let pre_note =
+            init_abar_to_ar_note(&mut prng, &oabar.clone(), &sender, &recv.pub_key).unwrap();
+
+        let hash = {
+            let mut hasher = Sha512::new();
+            let mut random_bytes = [0u8; 32];
+            prng.fill_bytes(&mut random_bytes);
+            hasher.update(&random_bytes);
+            hasher
+        };
+
+        let note = finish_abar_to_ar_note(&mut prng, &params, pre_note, hash.clone()).unwrap();
 
         let node_params = VerifierParams::abar_to_ar_params().unwrap();
-        verify_abar_to_ar_note(&node_params, &note, &proof.root).unwrap();
+        verify_abar_to_ar_note(&node_params, &note, &proof.root, hash.clone()).unwrap();
 
-        assert!(
-            verify_abar_to_ar_note(&node_params, &note, &BLSScalar::random(&mut prng),).is_err()
-        );
+        assert!(verify_abar_to_ar_note(
+            &node_params,
+            &note,
+            &BLSScalar::random(&mut prng),
+            hash.clone()
+        )
+        .is_err());
 
         let mut note_wrong_nullifier = note.clone();
         note_wrong_nullifier.body.input = BLSScalar::random(&mut prng);
-        assert!(verify_abar_to_ar_note(&node_params, &note_wrong_nullifier, &proof.root,).is_err());
+        assert!(verify_abar_to_ar_note(
+            &node_params,
+            &note_wrong_nullifier,
+            &proof.root,
+            hash.clone()
+        )
+        .is_err());
+
+        let hash2 = {
+            let mut hasher = Sha512::new();
+            let mut random_bytes = [0u8; 32];
+            prng.fill_bytes(&mut random_bytes);
+            hasher.update(&random_bytes);
+            hasher
+        };
+
+        assert!(verify_abar_to_ar_note(&node_params, &note, &proof.root, hash2).is_err())
     }
 
     fn hash_abar(uid: u64, abar: &AnonAssetRecord) -> BLSScalar {

--- a/api/src/anon_xfr/abar_to_bar.rs
+++ b/api/src/anon_xfr/abar_to_bar.rs
@@ -46,6 +46,17 @@ pub struct AbarToBarNote {
     pub non_malleability_tag: BLSScalar,
 }
 
+/// An anonymous-to-confidential note without the proof or non-malleability tag..
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AbarToBarPreNote {
+    /// The anonymous-to-confidential body.
+    pub body: AbarToBarBody,
+    /// Witness
+    pub witness: PayerWitness,
+    /// The non-malleability tag.
+    pub non_malleability_tag: BLSScalar,
+}
+
 /// An anonymous-to-confidential body.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AbarToBarBody {

--- a/api/src/anon_xfr/abar_to_bar.rs
+++ b/api/src/anon_xfr/abar_to_bar.rs
@@ -12,10 +12,9 @@ use crate::xfr::{
     sig::XfrPublicKey,
     structs::{AssetRecordTemplate, BlindAssetRecord, OwnerMemo, XfrAmount, XfrAssetType},
 };
-use digest::Digest;
+use digest::{consts::U64, Digest};
 use merlin::Transcript;
 use num_bigint::BigUint;
-use sha2::Sha512;
 use zei_algebra::{
     bls12_381::BLSScalar, jubjub::JubjubPoint, prelude::*, ristretto::RistrettoScalar,
 };
@@ -47,14 +46,20 @@ pub struct AbarToBarNote {
 }
 
 /// An anonymous-to-confidential note without the proof or non-malleability tag..
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug)]
 pub struct AbarToBarPreNote {
     /// The anonymous-to-confidential body.
     pub body: AbarToBarBody,
-    /// Witness
+    /// Witness.
     pub witness: PayerWitness,
-    /// The non-malleability tag.
-    pub non_malleability_tag: BLSScalar,
+    /// Input key pair.
+    pub input_keypair: AXfrKeyPair,
+    /// Inspection data in the delegated Chaum-Pedersen proof.
+    pub inspection: DelegatedChaumPedersenInspection,
+    /// Beta.
+    pub beta: RistrettoScalar,
+    /// Lambda.
+    pub lambda: RistrettoScalar,
 }
 
 /// An anonymous-to-confidential body.
@@ -74,15 +79,14 @@ pub struct AbarToBarBody {
     pub memo: Option<OwnerMemo>,
 }
 
-/// Generate the anonymous-to-confidential note.
-pub fn gen_abar_to_bar_note<R: CryptoRng + RngCore>(
+/// Generate the anonymous-to-confidential pre-note.
+pub fn init_abar_to_bar_note<R: CryptoRng + RngCore>(
     prng: &mut R,
-    params: &ProverParams,
     oabar: &OpenAnonAssetRecord,
     abar_keypair: &AXfrKeyPair,
     bar_pub_key: &XfrPublicKey,
     asset_record_type: AssetRecordType,
-) -> Result<AbarToBarNote> {
+) -> Result<AbarToBarPreNote> {
     if oabar.mt_leaf_info.is_none() || abar_keypair.get_pub_key() != oabar.pub_key {
         return Err(eg!(ZeiError::ParameterError));
     }
@@ -164,22 +168,46 @@ pub fn gen_abar_to_bar_note<R: CryptoRng + RngCore>(
         memo: owner_memo,
     };
 
-    let msg = bincode::serialize(&body)
-        .c(d!(ZeiError::SerializationError))
-        .c(d!())?;
+    Ok(AbarToBarPreNote {
+        body,
+        witness: payers_witness,
+        input_keypair: abar_keypair.clone(),
+        inspection: delegated_cp_inspection,
+        beta,
+        lambda,
+    })
+}
 
-    let (hash, non_malleability_randomizer, non_malleability_tag) =
-        compute_non_malleability_tag(prng, b"AbarToBar", &msg, &[&abar_keypair]);
+/// Finalize an anonymous-to-confidential note.
+pub fn finish_abar_to_bar_note<R: CryptoRng + RngCore, D: Digest<OutputSize = U64> + Default>(
+    prng: &mut R,
+    params: &ProverParams,
+    pre_note: AbarToBarPreNote,
+    hash: D,
+) -> Result<AbarToBarNote> {
+    let AbarToBarPreNote {
+        body,
+        witness,
+        input_keypair,
+        inspection,
+        beta,
+        lambda,
+    } = pre_note;
+
+    let hash_scalar = BLSScalar::from_hash::<D>(hash);
+
+    let (non_malleability_randomizer, non_malleability_tag) =
+        compute_non_malleability_tag(prng, hash_scalar, &[&input_keypair]);
 
     let proof = prove_abar_to_bar(
         prng,
         params,
-        payers_witness,
-        &delegated_cp_proof,
-        &delegated_cp_inspection,
+        witness,
+        &body.delegated_cp_proof,
+        &inspection,
         &beta,
         &lambda,
-        &hash,
+        &hash_scalar,
         &non_malleability_randomizer,
         &non_malleability_tag,
     )
@@ -193,10 +221,11 @@ pub fn gen_abar_to_bar_note<R: CryptoRng + RngCore>(
 }
 
 /// Verify the anonymous-to-confidential note.
-pub fn verify_abar_to_bar_note(
+pub fn verify_abar_to_bar_note<D: Digest<OutputSize = U64> + Default>(
     params: &VerifierParams,
     note: &AbarToBarNote,
     merkle_root: &BLSScalar,
+    hash: D,
 ) -> Result<()> {
     if *merkle_root != note.body.merkle_root {
         return Err(eg!(ZeiError::AXfrVerificationError));
@@ -258,36 +287,30 @@ pub fn verify_abar_to_bar_note(
     )
     .c(d!())?;
 
-    let mut transcript = Transcript::new(ABAR_TO_BAR_TRANSCRIPT);
-    let mut online_inputs = vec![];
-
-    online_inputs.push(input.clone());
-    online_inputs.push(merkle_root.clone());
+    let hash_scalar = BLSScalar::from_hash::<D>(hash);
 
     let delegated_cp_proof = note.body.delegated_cp_proof.clone();
 
     let beta_lambda = beta * &lambda;
     let s1_plus_lambda_s2 = delegated_cp_proof.s_1 + delegated_cp_proof.s_2 * &lambda;
 
-    online_inputs.push(delegated_cp_proof.inspection_comm);
     let beta_sim_fr = SimFr::from(&BigUint::from_bytes_le(&beta.to_bytes()));
     let lambda_sim_fr = SimFr::from(&BigUint::from_bytes_le(&lambda.to_bytes()));
     let beta_lambda_sim_fr = SimFr::from(&BigUint::from_bytes_le(&beta_lambda.to_bytes()));
     let s1_plus_lambda_s2_sim_fr =
         SimFr::from(&BigUint::from_bytes_le(&s1_plus_lambda_s2.to_bytes()));
+
+    let mut transcript = Transcript::new(ABAR_TO_BAR_TRANSCRIPT);
+    let mut online_inputs = vec![];
+
+    online_inputs.push(input.clone());
+    online_inputs.push(merkle_root.clone());
+    online_inputs.push(delegated_cp_proof.inspection_comm);
     online_inputs.extend_from_slice(&beta_sim_fr.limbs);
     online_inputs.extend_from_slice(&lambda_sim_fr.limbs);
     online_inputs.extend_from_slice(&beta_lambda_sim_fr.limbs);
     online_inputs.extend_from_slice(&s1_plus_lambda_s2_sim_fr.limbs);
-
-    let msg = bincode::serialize(&note.body)
-        .c(d!(ZeiError::SerializationError))
-        .c(d!())?;
-    let mut hasher = Sha512::new();
-    hasher.update(b"AbarToBar");
-    hasher.update(&msg);
-    let hash = BLSScalar::from_hash(hasher);
-    online_inputs.push(hash);
+    online_inputs.push(hash_scalar);
     online_inputs.push(note.non_malleability_tag);
 
     verifier(
@@ -648,7 +671,7 @@ pub fn build_abar_to_bar_cs(
 mod tests {
     use crate::anon_xfr::keys::AXfrKeyPair;
     use crate::anon_xfr::{
-        abar_to_bar::{gen_abar_to_bar_note, verify_abar_to_bar_note},
+        abar_to_bar::{finish_abar_to_bar_note, init_abar_to_bar_note, verify_abar_to_bar_note},
         structs::{AnonAssetRecord, MTLeafInfo, MTNode, MTPath, OpenAnonAssetRecordBuilder},
         TREE_DEPTH,
     };
@@ -657,9 +680,11 @@ mod tests {
         asset_record::AssetRecordType::ConfidentialAmount_ConfidentialAssetType, sig::XfrKeyPair,
         structs::AssetType,
     };
+    use digest::Digest;
     use mem_db::MemoryDB;
     use parking_lot::RwLock;
     use rand_chacha::ChaChaRng;
+    use sha2::Sha512;
     use std::sync::Arc;
     use storage::{
         state::{ChainState, State},
@@ -703,9 +728,8 @@ mod tests {
 
         oabar.update_mt_leaf_info(build_mt_leaf_info_from_proof(proof.clone()));
 
-        let note = gen_abar_to_bar_note(
+        let pre_note = init_abar_to_bar_note(
             &mut prng,
-            &params,
             &oabar.clone(),
             &sender,
             &recv.pub_key,
@@ -713,17 +737,45 @@ mod tests {
         )
         .unwrap();
 
+        let hash = {
+            let mut hasher = Sha512::new();
+            let mut random_bytes = [0u8; 32];
+            prng.fill_bytes(&mut random_bytes);
+            hasher.update(&random_bytes);
+            hasher
+        };
+
+        let note = finish_abar_to_bar_note(&mut prng, &params, pre_note, hash.clone()).unwrap();
+
         let node_params = VerifierParams::abar_to_bar_params().unwrap();
-        verify_abar_to_bar_note(&node_params, &note, &proof.root).unwrap();
-        assert!(
-            verify_abar_to_bar_note(&node_params, &note, &BLSScalar::random(&mut prng),).is_err()
-        );
+        verify_abar_to_bar_note(&node_params, &note, &proof.root, hash.clone()).unwrap();
+        assert!(verify_abar_to_bar_note(
+            &node_params,
+            &note,
+            &BLSScalar::random(&mut prng),
+            hash.clone()
+        )
+        .is_err());
 
         let mut note_wrong_nullifier = note.clone();
         note_wrong_nullifier.body.input = BLSScalar::random(&mut prng);
-        assert!(
-            verify_abar_to_bar_note(&node_params, &note_wrong_nullifier, &proof.root,).is_err()
-        );
+        assert!(verify_abar_to_bar_note(
+            &node_params,
+            &note_wrong_nullifier,
+            &proof.root,
+            hash.clone()
+        )
+        .is_err());
+
+        let hash2 = {
+            let mut hasher = Sha512::new();
+            let mut random_bytes = [0u8; 32];
+            prng.fill_bytes(&mut random_bytes);
+            hasher.update(&random_bytes);
+            hasher
+        };
+
+        assert!(verify_abar_to_bar_note(&node_params, &note, &proof.root, hash2).is_err())
     }
 
     fn hash_abar(uid: u64, abar: &AnonAssetRecord) -> BLSScalar {

--- a/api/src/anon_xfr/mod.rs
+++ b/api/src/anon_xfr/mod.rs
@@ -3,9 +3,7 @@ use crate::anon_xfr::structs::{
     NullifierInputVars, OpenAnonAssetRecord,
 };
 use crate::xfr::structs::{AssetType, ASSET_TYPE_LENGTH};
-use digest::Digest;
 use keys::AXfrKeyPair;
-use sha2::Sha512;
 use zei_algebra::{
     bls12_381::{BLSScalar, BLS12_381_SCALAR_LEN},
     collections::HashMap,
@@ -120,15 +118,11 @@ fn check_roots(inputs: &[OpenAnonAssetRecord]) -> Result<()> {
 }
 
 /// Compute the non-malleability tag given the information and the secret keys.
-pub fn compute_non_malleability_tag<
-    R: CryptoRng + RngCore,
-    D: Digest<OutputSize = U64> + Default,
->(
+pub fn compute_non_malleability_tag<R: CryptoRng + RngCore>(
     prng: &mut R,
-    hash: D,
+    hash_scalar: BLSScalar,
     secret_keys: &[&AXfrKeyPair],
 ) -> (BLSScalar, BLSScalar) {
-    let hash_scalar = BLSScalar::from_hash::<D>(hash);
     let randomizer = BLSScalar::random(prng);
 
     let mut input_to_rescue = vec![];

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'zei-crypto'
-version = '0.1.4'
+version = '0.2.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 description = 'Zei Cryptographic Primitives and Protocols'

--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -5,7 +5,7 @@ harness = false
 
 [package]
 name = 'zei-plonk'
-version = '0.1.4'
+version = '0.2.0'
 authors = ['Findora <engineering@findora.org>']
 edition = '2021'
 description = 'Zei TurboPLONK protocol'

--- a/plonk/src/plonk/prover.rs
+++ b/plonk/src/plonk/prover.rs
@@ -1,4 +1,3 @@
-use crate::plonk::transcript::transcript_get_plonk_challenge_u;
 use crate::plonk::{
     constraint_system::ConstraintSystem,
     errors::PlonkError,
@@ -8,8 +7,8 @@ use crate::plonk::{
     indexer::{PlonkPK, PlonkPf, PlonkProof},
     transcript::{
         transcript_get_plonk_challenge_alpha, transcript_get_plonk_challenge_beta,
-        transcript_get_plonk_challenge_gamma, transcript_get_plonk_challenge_zeta,
-        transcript_init_plonk,
+        transcript_get_plonk_challenge_gamma, transcript_get_plonk_challenge_u,
+        transcript_get_plonk_challenge_zeta, transcript_init_plonk,
     },
 };
 use crate::poly_commit::{


### PR DESCRIPTION
* **The major changes of this PR**

This PR changes the logic of non-malleability to sign on the entire transaction's body instead of an operation's body. This is related to the mainnet  https://github.com/FindoraNetwork/platform/pull/345.

* **The major impacts of this PR**
  - [x] Impact WASM?
  - [x] Impact mainnet data compatibility?

Luckily TM is not yet on the mainnet, but it needs to work with that PR.

* **Extra documentations**

