### PR TITLE
Set the AES-GCM version to exactly 0.10.0-pre

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ['rlib']
 
 [dependencies]
 aes = '0.8.1'
-aes-gcm = '0.10.0-pre'
+aes-gcm = '=0.10.0-pre'
 bincode = '1.3.1'
 bulletproofs = "2.0"
 digest = '0.10'

--- a/api/src/anon_xfr/structs.rs
+++ b/api/src/anon_xfr/structs.rs
@@ -3,7 +3,7 @@ use crate::anon_xfr::{
     keys::{AXfrKeyPair, AXfrPubKey, AXfrViewKey},
 };
 use crate::xfr::structs::AssetType;
-use aes_gcm::{aead::Aead, KeyInit};
+use aes_gcm::{aead::Aead, NewAead};
 use digest::{generic_array::GenericArray, Digest};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
* **The major changes of this PR**

A recent update in the AES-GCM upstream creates a new version 0.10.0-pre.1, which introduces a breaking change.

To avoid such unintended version breaking happening, we decide to set the AES-GCM version to be exactly 0.10.0-pre.

The reason that we choose 0.10.0-pre instead of 0.10.0-pre.1 is because the latter seems more likely a temporary version that might be yanked in the future.

Notify @sunhuachuang regarding this reversion change.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

