### PR TITLE
Implement the Default trait for the public keys in confidential transfer

### DIFF
--- a/api/src/xfr/sig.rs
+++ b/api/src/xfr/sig.rs
@@ -67,6 +67,13 @@ pub enum XfrPublicKey {
     Secp256k1(Secp256k1PublicKey),
 }
 
+impl Default for XfrPublicKey {
+    fn default() -> Self {
+        let secret_key = Secp256k1SecretKey::default();
+        XfrPublicKey::Secp256k1(Secp256k1PublicKey::from_secret_key(&secret_key))
+    }
+}
+
 #[derive(Debug)]
 /// The secret key for confidential transfer.
 pub enum XfrSecretKey {

--- a/api/src/xfr/sig.rs
+++ b/api/src/xfr/sig.rs
@@ -69,8 +69,7 @@ pub enum XfrPublicKey {
 
 impl Default for XfrPublicKey {
     fn default() -> Self {
-        let secret_key = Secp256k1SecretKey::default();
-        XfrPublicKey::Secp256k1(Secp256k1PublicKey::from_secret_key(&secret_key))
+        XfrPublicKey::Ed25519(Ed25519PublicKey::default())
     }
 }
 


### PR DESCRIPTION
* **The major changes of this PR**

It appears that the platform wants to use a default public key. This is, however, not automatically definable for enum.

Here, we pick the Ed25519 as the default because it has already a defined Default.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

