### PR TITLE
Let XfrPublicKey have WASM binding

### DIFF
--- a/api/src/serialization.rs
+++ b/api/src/serialization.rs
@@ -61,6 +61,7 @@ mod test {
     use crate::anon_xfr::keys::{AXfrKeyPair, AXfrPubKey};
     use crate::ristretto::CompressedRistretto;
     use crate::serialization::ZeiFromToBytes;
+    use crate::xfr::sig::XfrPublicKeyInner;
     use crate::xfr::{
         asset_tracer::RecordDataEncKey,
         sig::{XfrKeyPair, XfrPublicKey, XfrSecretKey, XfrSignature},
@@ -108,7 +109,7 @@ mod test {
             blind_asset_record: BlindAssetRecord {
                 amount: blind_amount,
                 asset_type: blind_type,
-                public_key: XfrPublicKey::Ed25519(Default::default()),
+                public_key: XfrPublicKey(XfrPublicKeyInner::Ed25519(Default::default())),
             },
             amount: amt,
             amount_blinds: (Default::default(), Default::default()),

--- a/api/src/xfr/sig.rs
+++ b/api/src/xfr/sig.rs
@@ -67,6 +67,13 @@ pub enum XfrPublicKey {
     Secp256k1(Secp256k1PublicKey),
 }
 
+impl Default for XfrPublicKey {
+    fn default() -> Self {
+        let secret_key = Secp256k1SecretKey::default();
+        XfrPublicKey::Secp256k1(Secp256k1PublicKey::from_secret_key(&secret_key))
+    }
+}
+
 #[derive(Debug)]
 /// The secret key for confidential transfer.
 pub enum XfrSecretKey {

--- a/api/src/xfr/sig.rs
+++ b/api/src/xfr/sig.rs
@@ -69,8 +69,7 @@ pub enum XfrPublicKey {
 
 impl Default for XfrPublicKey {
     fn default() -> Self {
-        let secret_key = Secp256k1SecretKey::default();
-        XfrPublicKey::Secp256k1(Secp256k1PublicKey::from_secret_key(&secret_key))
+        XfrPublicKey::Ed25519(Ed25519PublicKey::default())
     }
 }
 


### PR DESCRIPTION
* **The major changes of this PR**

To allow `wasm_bindgen` for some data structures, here enum, as a standard workaround in this library, we wrap around the original structure with pub(crate).

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

