### PR TITLE
Switch to secq256k1 curve

### DIFF
--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -76,8 +76,8 @@ version = "0.2"
 [dependencies.num-integer]
 version = "0.1"
 
-[dependencies.ark-bulletproofs-canaan]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-canaan"
+[dependencies.ark-bulletproofs-secq256k1]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
 default-features = false
 features = ['yoloproofs']
 
@@ -94,7 +94,7 @@ std = [
     'ark-std/std',
     'ark-ff/std',
     'ark-serialize/std',
-    'ark-bulletproofs-canaan/std'
+    'ark-bulletproofs-secq256k1/std'
 ]
 alloc = ['curve25519-dalek/alloc']
 nightly = ['curve25519-dalek/nightly']
@@ -105,6 +105,6 @@ parallel = [
     'rayon',
     'ark-ec/parallel',
     'ark-ff/parallel',
-    'ark-bulletproofs-canaan/parallel'
+    'ark-bulletproofs-secq256k1/parallel'
 ]
 asm = ['ark-ff/asm']

--- a/algebra/src/lib.rs
+++ b/algebra/src/lib.rs
@@ -23,8 +23,8 @@
 /// Module for the BLS12-381 curve
 pub mod bls12_381;
 
-/// Module for the Canaan curve
-pub mod canaan;
+/// Module for the secq256k1 curve
+pub mod secq256k1;
 
 /// Module for the secp256k1 curve
 pub mod secp256k1;

--- a/algebra/src/secp256k1.rs
+++ b/algebra/src/secp256k1.rs
@@ -1,7 +1,7 @@
-use crate::canaan::CanaanScalar;
 use crate::errors::AlgebraError;
 use crate::prelude::*;
-use ark_bulletproofs_canaan::curve::secp256k1::{Fr, FrParameters, G1Affine, G1Projective};
+use crate::secq256k1::SECQ256K1Scalar;
+use ark_bulletproofs_secq256k1::curve::secp256k1::{Fr, FrParameters, G1Affine, G1Projective};
 use ark_ec::short_weierstrass_jacobian::GroupProjective;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BigInteger320, FftField, FftParameters, Field, FpParameters, PrimeField};
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 /// The number of bytes for a scalar value over secp256k1
 pub const SECP256K1_SCALAR_LEN: usize = 32;
 
-/// The wrapped struct for `ark_bulletproofs_canaan::curve::secp256k1::Fr`
+/// The wrapped struct for `ark_bulletproofs_secq256k1::curve::secp256k1::Fr`
 #[wasm_bindgen]
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct SECP256K1Scalar(pub(crate) Fr);
@@ -49,7 +49,7 @@ impl SECP256K1Scalar {
     }
 }
 
-/// The wrapped struct for `ark_bulletproofs_canaan::curve::secp256k1::G1Projective`
+/// The wrapped struct for `ark_bulletproofs_secq256k1::curve::secp256k1::G1Projective`
 #[wasm_bindgen]
 #[derive(Copy, Default, Clone, PartialEq, Eq, Hash)]
 pub struct SECP256K1G1(pub(crate) G1Projective);
@@ -208,7 +208,7 @@ impl Scalar for SECP256K1Scalar {
 
     #[inline]
     fn capacity() -> usize {
-        ark_bulletproofs_canaan::curve::secp256k1::FrParameters::CAPACITY as usize
+        ark_bulletproofs_secq256k1::curve::secp256k1::FrParameters::CAPACITY as usize
     }
 
     #[inline]
@@ -297,17 +297,17 @@ impl SECP256K1Scalar {
 
 impl SECP256K1G1 {
     /// Obtain the x coordinate in the affine representation.
-    pub fn get_x(&self) -> CanaanScalar {
-        CanaanScalar((self.0.into_affine().x).clone())
+    pub fn get_x(&self) -> SECQ256K1Scalar {
+        SECQ256K1Scalar((self.0.into_affine().x).clone())
     }
 
     /// Obtain the y coordinate in the affine representation.
-    pub fn get_y(&self) -> CanaanScalar {
-        CanaanScalar((self.0.into_affine().y).clone())
+    pub fn get_y(&self) -> SECQ256K1Scalar {
+        SECQ256K1Scalar((self.0.into_affine().y).clone())
     }
 
-    /// Obtain a point using the x coordinate (which would be CanaanScalar).
-    pub fn get_point_from_x(x: &CanaanScalar) -> Result<Self> {
+    /// Obtain a point using the x coordinate (which would be SECQ256K1Scalar).
+    pub fn get_point_from_x(x: &SECQ256K1Scalar) -> Result<Self> {
         let point = G1Affine::get_point_from_x(x.0.clone(), false)
             .ok_or(eg!(ZeiError::DeserializationError))?
             .into_projective();
@@ -492,7 +492,7 @@ mod secp256k1_groups_test {
         secp256k1::{SECP256K1Scalar, SECP256K1G1},
         traits::group_tests::{test_scalar_operations, test_scalar_serialization},
     };
-    use ark_bulletproofs_canaan::curve::secp256k1::G1Affine;
+    use ark_bulletproofs_secq256k1::curve::secp256k1::G1Affine;
     use ark_ec::ProjectiveCurve;
     use rand_chacha::ChaCha20Rng;
 

--- a/algebra/src/secq256k1.rs
+++ b/algebra/src/secq256k1.rs
@@ -1,6 +1,6 @@
 use crate::errors::AlgebraError;
 use crate::prelude::*;
-use ark_bulletproofs_canaan::curve::canaan::{Fr, FrParameters, G1Affine, G1Projective};
+use ark_bulletproofs_secq256k1::curve::secq256k1::{Fr, FrParameters, G1Affine, G1Projective};
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{BigInteger, BigInteger320, FftField, FftParameters, Field, FpParameters, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -17,15 +17,15 @@ use num_traits::Num;
 use ruc::eg;
 use wasm_bindgen::prelude::*;
 
-/// The number of bytes for a scalar value over the Canaan curve
-pub const CANAAN_SCALAR_LEN: usize = 32;
+/// The number of bytes for a scalar value over the secq256k1 curve
+pub const SECQ256K1_SCALAR_LEN: usize = 32;
 
-/// The wrapped struct for `ark_bulletproofs_canaan::curve::canaan::Fr`
+/// The wrapped struct for `ark_bulletproofs_secq256k1::curve::secq256k1::Fr`
 #[wasm_bindgen]
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct CanaanScalar(pub(crate) Fr);
+pub struct SECQ256K1Scalar(pub(crate) Fr);
 
-impl Debug for CanaanScalar {
+impl Debug for SECQ256K1Scalar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         <BigUint as Debug>::fmt(
             &<BigInteger320 as Into<BigUint>>::into(self.0.into_repr()),
@@ -34,18 +34,18 @@ impl Debug for CanaanScalar {
     }
 }
 
-/// The wrapped struct for `ark_bulletproofs_canaan::curve::canaan::G1Projective`
+/// The wrapped struct for `ark_bulletproofs_secq256k1::curve::secq256k1::G1Projective`
 #[wasm_bindgen]
 #[derive(Copy, Default, Clone, PartialEq, Eq)]
-pub struct CanaanG1(pub(crate) G1Projective);
+pub struct SECQ256K1G1(pub(crate) G1Projective);
 
-impl Debug for CanaanG1 {
+impl Debug for SECQ256K1G1 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.0.into_affine(), f)
     }
 }
 
-impl FromStr for CanaanScalar {
+impl FromStr for SECQ256K1Scalar {
     type Err = AlgebraError;
 
     fn from_str(string: &str) -> StdResult<Self, AlgebraError> {
@@ -59,14 +59,14 @@ impl FromStr for CanaanScalar {
     }
 }
 
-impl One for CanaanScalar {
+impl One for SECQ256K1Scalar {
     #[inline]
     fn one() -> Self {
-        CanaanScalar(Fr::one())
+        SECQ256K1Scalar(Fr::one())
     }
 }
 
-impl Zero for CanaanScalar {
+impl Zero for SECQ256K1Scalar {
     #[inline]
     fn zero() -> Self {
         Self(Fr::zero())
@@ -78,8 +78,8 @@ impl Zero for CanaanScalar {
     }
 }
 
-impl Add for CanaanScalar {
-    type Output = CanaanScalar;
+impl Add for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn add(self, rhs: Self) -> Self::Output {
@@ -87,8 +87,8 @@ impl Add for CanaanScalar {
     }
 }
 
-impl Mul for CanaanScalar {
-    type Output = CanaanScalar;
+impl Mul for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn mul(self, rhs: Self) -> Self::Output {
@@ -96,8 +96,8 @@ impl Mul for CanaanScalar {
     }
 }
 
-impl<'a> Add<&'a CanaanScalar> for CanaanScalar {
-    type Output = CanaanScalar;
+impl<'a> Add<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn add(self, rhs: &Self) -> Self::Output {
@@ -105,15 +105,15 @@ impl<'a> Add<&'a CanaanScalar> for CanaanScalar {
     }
 }
 
-impl<'a> AddAssign<&'a CanaanScalar> for CanaanScalar {
+impl<'a> AddAssign<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
     #[inline]
     fn add_assign(&mut self, rhs: &Self) {
         (self.0).add_assign(&rhs.0);
     }
 }
 
-impl<'a> Sub<&'a CanaanScalar> for CanaanScalar {
-    type Output = CanaanScalar;
+impl<'a> Sub<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn sub(self, rhs: &Self) -> Self::Output {
@@ -121,15 +121,15 @@ impl<'a> Sub<&'a CanaanScalar> for CanaanScalar {
     }
 }
 
-impl<'a> SubAssign<&'a CanaanScalar> for CanaanScalar {
+impl<'a> SubAssign<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
     #[inline]
     fn sub_assign(&mut self, rhs: &Self) {
         (self.0).sub_assign(&rhs.0);
     }
 }
 
-impl<'a> Mul<&'a CanaanScalar> for CanaanScalar {
-    type Output = CanaanScalar;
+impl<'a> Mul<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn mul(self, rhs: &Self) -> Self::Output {
@@ -137,15 +137,15 @@ impl<'a> Mul<&'a CanaanScalar> for CanaanScalar {
     }
 }
 
-impl<'a> MulAssign<&'a CanaanScalar> for CanaanScalar {
+impl<'a> MulAssign<&'a SECQ256K1Scalar> for SECQ256K1Scalar {
     #[inline]
     fn mul_assign(&mut self, rhs: &Self) {
         (self.0).mul_assign(&rhs.0);
     }
 }
 
-impl Neg for CanaanScalar {
-    type Output = CanaanScalar;
+impl Neg for SECQ256K1Scalar {
+    type Output = SECQ256K1Scalar;
 
     #[inline]
     fn neg(self) -> Self {
@@ -153,21 +153,21 @@ impl Neg for CanaanScalar {
     }
 }
 
-impl From<u32> for CanaanScalar {
+impl From<u32> for SECQ256K1Scalar {
     #[inline]
     fn from(value: u32) -> Self {
         Self::from(value as u64)
     }
 }
 
-impl From<u64> for CanaanScalar {
+impl From<u64> for SECQ256K1Scalar {
     #[inline]
     fn from(value: u64) -> Self {
         Self(Fr::from(value))
     }
 }
 
-impl Scalar for CanaanScalar {
+impl Scalar for SECQ256K1Scalar {
     #[inline]
     fn random<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
         Self(Fr::rand(rng))
@@ -184,7 +184,7 @@ impl Scalar for CanaanScalar {
 
     #[inline]
     fn capacity() -> usize {
-        ark_bulletproofs_canaan::curve::canaan::FrParameters::CAPACITY as usize
+        ark_bulletproofs_secq256k1::curve::secq256k1::FrParameters::CAPACITY as usize
     }
 
     #[inline]
@@ -224,12 +224,12 @@ impl Scalar for CanaanScalar {
 
     #[inline]
     fn bytes_len() -> usize {
-        CANAAN_SCALAR_LEN
+        SECQ256K1_SCALAR_LEN
     }
 
     #[inline]
     fn to_bytes(&self) -> Vec<u8> {
-        self.0.into_repr().to_bytes_le()[..CANAAN_SCALAR_LEN].to_vec()
+        self.0.into_repr().to_bytes_le()[..SECQ256K1_SCALAR_LEN].to_vec()
     }
 
     #[inline]
@@ -260,7 +260,7 @@ impl Scalar for CanaanScalar {
     }
 }
 
-impl CanaanScalar {
+impl SECQ256K1Scalar {
     /// Get the raw data.
     pub fn get_raw(&self) -> Fr {
         self.0.clone()
@@ -272,7 +272,7 @@ impl CanaanScalar {
     }
 }
 
-impl Neg for CanaanG1 {
+impl Neg for SECQ256K1G1 {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
@@ -280,8 +280,8 @@ impl Neg for CanaanG1 {
     }
 }
 
-impl Group for CanaanG1 {
-    type ScalarType = CanaanScalar;
+impl Group for SECQ256K1G1 {
+    type ScalarType = SECQ256K1Scalar;
     const COMPRESSED_LEN: usize = 33;
 
     #[inline]
@@ -301,7 +301,7 @@ impl Group for CanaanG1 {
 
     #[inline]
     fn random<R: CryptoRng + RngCore>(prng: &mut R) -> Self {
-        Self::get_base().mul(&CanaanScalar::random(prng))
+        Self::get_base().mul(&SECQ256K1Scalar::random(prng))
     }
 
     #[inline]
@@ -377,7 +377,7 @@ impl Group for CanaanG1 {
     }
 }
 
-impl Into<BigUint> for CanaanScalar {
+impl Into<BigUint> for SECQ256K1Scalar {
     #[inline]
     fn into(self) -> BigUint {
         let value: BigUint = self.0.into_repr().into();
@@ -385,14 +385,14 @@ impl Into<BigUint> for CanaanScalar {
     }
 }
 
-impl<'a> From<&'a BigUint> for CanaanScalar {
+impl<'a> From<&'a BigUint> for SECQ256K1Scalar {
     #[inline]
     fn from(value: &'a BigUint) -> Self {
         Self(Fr::from(value.clone()))
     }
 }
 
-impl CanaanG1 {
+impl SECQ256K1G1 {
     /// Get the raw data.
     pub fn get_raw(&self) -> G1Affine {
         self.0.into_affine()
@@ -404,8 +404,8 @@ impl CanaanG1 {
     }
 }
 
-impl<'a> Add<&'a CanaanG1> for CanaanG1 {
-    type Output = CanaanG1;
+impl<'a> Add<&'a SECQ256K1G1> for SECQ256K1G1 {
+    type Output = SECQ256K1G1;
 
     #[inline]
     fn add(self, rhs: &Self) -> Self::Output {
@@ -413,8 +413,8 @@ impl<'a> Add<&'a CanaanG1> for CanaanG1 {
     }
 }
 
-impl<'a> Sub<&'a CanaanG1> for CanaanG1 {
-    type Output = CanaanG1;
+impl<'a> Sub<&'a SECQ256K1G1> for SECQ256K1G1 {
+    type Output = SECQ256K1G1;
 
     #[inline]
     fn sub(self, rhs: &Self) -> Self::Output {
@@ -422,60 +422,60 @@ impl<'a> Sub<&'a CanaanG1> for CanaanG1 {
     }
 }
 
-impl<'a> Mul<&'a CanaanScalar> for CanaanG1 {
-    type Output = CanaanG1;
+impl<'a> Mul<&'a SECQ256K1Scalar> for SECQ256K1G1 {
+    type Output = SECQ256K1G1;
 
     #[inline]
-    fn mul(self, rhs: &CanaanScalar) -> Self::Output {
+    fn mul(self, rhs: &SECQ256K1Scalar) -> Self::Output {
         Self(self.0.mul(&rhs.0.into_repr()))
     }
 }
 
-impl<'a> AddAssign<&'a CanaanG1> for CanaanG1 {
+impl<'a> AddAssign<&'a SECQ256K1G1> for SECQ256K1G1 {
     #[inline]
-    fn add_assign(&mut self, rhs: &'a CanaanG1) {
+    fn add_assign(&mut self, rhs: &'a SECQ256K1G1) {
         self.0.add_assign(&rhs.0)
     }
 }
 
-impl<'a> SubAssign<&'a CanaanG1> for CanaanG1 {
+impl<'a> SubAssign<&'a SECQ256K1G1> for SECQ256K1G1 {
     #[inline]
-    fn sub_assign(&mut self, rhs: &'a CanaanG1) {
+    fn sub_assign(&mut self, rhs: &'a SECQ256K1G1) {
         self.0.sub_assign(&rhs.0)
     }
 }
 
-impl<'a> MulAssign<&'a CanaanScalar> for CanaanG1 {
+impl<'a> MulAssign<&'a SECQ256K1Scalar> for SECQ256K1G1 {
     #[inline]
-    fn mul_assign(&mut self, rhs: &'a CanaanScalar) {
+    fn mul_assign(&mut self, rhs: &'a SECQ256K1Scalar) {
         self.0.mul_assign(rhs.0.clone())
     }
 }
 
 #[cfg(test)]
-mod canaan_groups_test {
+mod secq256k1_groups_test {
     use crate::{
-        canaan::{CanaanG1, CanaanScalar},
         prelude::*,
+        secq256k1::{SECQ256K1Scalar, SECQ256K1G1},
         traits::group_tests::{test_scalar_operations, test_scalar_serialization},
     };
-    use ark_bulletproofs_canaan::curve::canaan::G1Affine;
+    use ark_bulletproofs_secq256k1::curve::secq256k1::G1Affine;
     use ark_ec::ProjectiveCurve;
     use rand_chacha::ChaCha20Rng;
 
     #[test]
     fn test_scalar_ops() {
-        test_scalar_operations::<CanaanScalar>();
+        test_scalar_operations::<SECQ256K1Scalar>();
     }
 
     #[test]
     fn scalar_deser() {
-        test_scalar_serialization::<CanaanScalar>();
+        test_scalar_serialization::<SECQ256K1Scalar>();
     }
 
     #[test]
     fn scalar_from_to_bytes() {
-        let small_value = CanaanScalar::from(165747u32);
+        let small_value = SECQ256K1Scalar::from(165747u32);
         let small_value_bytes = small_value.to_bytes();
         let expected_small_value_bytes: [u8; 32] = [
             115, 135, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -483,7 +483,7 @@ mod canaan_groups_test {
         ];
         assert_eq!(small_value_bytes, expected_small_value_bytes);
 
-        let small_value_from_bytes = CanaanScalar::from_bytes(&small_value_bytes).unwrap();
+        let small_value_from_bytes = SECQ256K1Scalar::from_bytes(&small_value_bytes).unwrap();
         assert_eq!(small_value_from_bytes, small_value);
     }
 
@@ -491,12 +491,12 @@ mod canaan_groups_test {
     fn curve_points_respresentation_of_g1() {
         let mut rng = ChaCha20Rng::from_entropy();
 
-        let g1 = CanaanG1::get_base();
-        let s1 = CanaanScalar::from(50 + rng.next_u32() % 50);
+        let g1 = SECQ256K1G1::get_base();
+        let s1 = SECQ256K1Scalar::from(50 + rng.next_u32() % 50);
 
         let g1 = g1.mul(&s1);
 
-        let g1_prime = CanaanG1::random(&mut rng);
+        let g1_prime = SECQ256K1G1::random(&mut rng);
 
         // This is the projective representation of g1
         let g1_projective = g1.0;
@@ -520,9 +520,9 @@ mod canaan_groups_test {
     fn test_serialization_of_points() {
         let mut rng = ChaCha20Rng::from_entropy();
 
-        let g1 = CanaanG1::random(&mut rng);
+        let g1 = SECQ256K1G1::random(&mut rng);
         let g1_bytes = g1.to_compressed_bytes();
-        let g1_recovered = CanaanG1::from_compressed_bytes(&g1_bytes).unwrap();
+        let g1_recovered = SECQ256K1G1::from_compressed_bytes(&g1_bytes).unwrap();
         assert_eq!(g1, g1_recovered);
     }
 }

--- a/algebra/src/serialization.rs
+++ b/algebra/src/serialization.rs
@@ -1,10 +1,10 @@
-use crate::canaan::CanaanG1;
 use crate::secp256k1::{SECP256K1Scalar, SECP256K1G1};
+use crate::secq256k1::SECQ256K1G1;
 use crate::{
     bls12_381::{BLSGt, BLSScalar, BLSG1, BLSG2},
-    canaan::CanaanScalar,
     prelude::*,
     ristretto::{CompressedEdwardsY, CompressedRistretto, RistrettoPoint, RistrettoScalar},
+    secq256k1::SECQ256K1Scalar,
 };
 use bulletproofs::RangeProof;
 use serde::Serializer;
@@ -27,7 +27,7 @@ macro_rules! to_from_bytes_scalar {
 
 to_from_bytes_scalar!(RistrettoScalar);
 to_from_bytes_scalar!(BLSScalar);
-to_from_bytes_scalar!(CanaanScalar);
+to_from_bytes_scalar!(SECQ256K1Scalar);
 to_from_bytes_scalar!(SECP256K1Scalar);
 
 impl ZeiFromToBytes for CompressedRistretto {
@@ -60,7 +60,7 @@ serialize_deserialize!(CompressedRistretto);
 serialize_deserialize!(CompressedEdwardsY);
 serialize_deserialize!(RistrettoScalar);
 serialize_deserialize!(BLSScalar);
-serialize_deserialize!(CanaanScalar);
+serialize_deserialize!(SECQ256K1Scalar);
 serialize_deserialize!(SECP256K1Scalar);
 
 macro_rules! to_from_bytes_group {
@@ -81,14 +81,14 @@ to_from_bytes_group!(RistrettoPoint);
 to_from_bytes_group!(BLSG1);
 to_from_bytes_group!(BLSG2);
 to_from_bytes_group!(BLSGt);
-to_from_bytes_group!(CanaanG1);
+to_from_bytes_group!(SECQ256K1G1);
 to_from_bytes_group!(SECP256K1G1);
 
 serialize_deserialize!(RistrettoPoint);
 serialize_deserialize!(BLSG1);
 serialize_deserialize!(BLSG2);
 serialize_deserialize!(BLSGt);
-serialize_deserialize!(CanaanG1);
+serialize_deserialize!(SECQ256K1G1);
 serialize_deserialize!(SECP256K1G1);
 
 /// Helper trait to serialize zei and foreign objects that implement from/to bytes/bits
@@ -120,12 +120,12 @@ impl ZeiFromToBytes for bulletproofs::r1cs::R1CSProof {
     }
 }
 
-impl ZeiFromToBytes for ark_bulletproofs_canaan::r1cs::R1CSProof {
+impl ZeiFromToBytes for ark_bulletproofs_secq256k1::r1cs::R1CSProof {
     fn zei_to_bytes(&self) -> Vec<u8> {
         self.to_bytes().unwrap()
     }
-    fn zei_from_bytes(bytes: &[u8]) -> Result<ark_bulletproofs_canaan::r1cs::R1CSProof> {
-        ark_bulletproofs_canaan::r1cs::R1CSProof::from_bytes(bytes)
+    fn zei_from_bytes(bytes: &[u8]) -> Result<ark_bulletproofs_secq256k1::r1cs::R1CSProof> {
+        ark_bulletproofs_secq256k1::r1cs::R1CSProof::from_bytes(bytes)
             .map_err(|_| eg!(ZeiError::DeserializationError))
     }
 }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -101,8 +101,8 @@ tag = 'v0.2.1'
 git = 'https://github.com/FindoraNetwork/storage.git'
 tag = 'v0.2.1'
 
-[dependencies.ark-bulletproofs-canaan]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-canaan"
+[dependencies.ark-bulletproofs-secq256k1]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
 default-features = false
 features = ["yoloproofs"]
 
@@ -112,7 +112,7 @@ default = [
     'u64_backend',
 ]
 debug = [ 'zei-plonk/debug' ]
-std = ['curve25519-dalek/std', 'bulletproofs/std', 'ark-bulletproofs-canaan/std']
+std = ['curve25519-dalek/std', 'bulletproofs/std', 'ark-bulletproofs-secq256k1/std']
 alloc = ['curve25519-dalek/alloc']
 nightly = [
     'curve25519-dalek/nightly',

--- a/api/src/anon_xfr/address_folding.rs
+++ b/api/src/anon_xfr/address_folding.rs
@@ -5,16 +5,16 @@ use merlin::Transcript;
 use num_bigint::BigUint;
 use rand_core::{CryptoRng, RngCore};
 use zei_algebra::bls12_381::BLSScalar;
-use zei_algebra::canaan::{CanaanG1, CanaanScalar};
 use zei_algebra::prelude::*;
 use zei_algebra::secp256k1::SECP256K1Scalar;
-use zei_crypto::basic::pedersen_comm::PedersenCommitmentCanaan;
+use zei_algebra::secq256k1::{SECQ256K1Scalar, SECQ256K1G1};
+use zei_crypto::basic::pedersen_comm::PedersenCommitmentSecq256k1;
 use zei_crypto::bulletproofs::scalar_mul::ScalarMulProof;
 use zei_crypto::delegated_chaum_pedersen::{
     prove_delegated_chaum_pedersen, verify_delegated_chaum_pedersen,
     DelegatedChaumPedersenInspection, DelegatedChaumPedersenProof,
 };
-use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsCanaan};
+use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsSecq256k1};
 use zei_plonk::plonk::constraint_system::field_simulation::SimFrVar;
 use zei_plonk::plonk::constraint_system::rescue::StateVar;
 use zei_plonk::plonk::constraint_system::VarIndex;
@@ -23,9 +23,10 @@ use zei_plonk::plonk::constraint_system::VarIndex;
 /// The instance for address folding.
 pub struct AXfrAddressFoldingInstance {
     /// The inspector's proof.
-    pub delegated_cp_proof: DelegatedChaumPedersenProof<CanaanScalar, CanaanG1, SimFrParamsCanaan>,
+    pub delegated_cp_proof:
+        DelegatedChaumPedersenProof<SECQ256K1Scalar, SECQ256K1G1, SimFrParamsSecq256k1>,
     /// The commitments generated during the scalar mul proof, used in delegated CP.
-    pub scalar_mul_commitments: Vec<CanaanG1>,
+    pub scalar_mul_commitments: Vec<SECQ256K1G1>,
     /// The scalar mul proof.
     pub scalar_mul_proof: ScalarMulProof,
 }
@@ -36,38 +37,42 @@ pub struct AXfrAddressFoldingWitness {
     /// The key pair
     pub keypair: AXfrKeyPair,
     /// Blinding factors of the commitments
-    pub blinding_factors: Vec<CanaanScalar>,
+    pub blinding_factors: Vec<SECQ256K1Scalar>,
     /// The inspector's proof.
-    pub delegated_cp_proof: DelegatedChaumPedersenProof<CanaanScalar, CanaanG1, SimFrParamsCanaan>,
+    pub delegated_cp_proof:
+        DelegatedChaumPedersenProof<SECQ256K1Scalar, SECQ256K1G1, SimFrParamsSecq256k1>,
     /// Inspection data in the delegated Chaum-Pedersen proof.
     pub delegated_cp_inspection:
-        DelegatedChaumPedersenInspection<CanaanScalar, CanaanG1, SimFrParamsCanaan>,
+        DelegatedChaumPedersenInspection<SECQ256K1Scalar, SECQ256K1G1, SimFrParamsSecq256k1>,
     /// Beta.
-    pub beta: CanaanScalar,
+    pub beta: SECQ256K1Scalar,
     /// Lambda.
-    pub lambda: CanaanScalar,
+    pub lambda: SECQ256K1Scalar,
 }
 
 impl Default for AXfrAddressFoldingWitness {
     fn default() -> Self {
         let keypair = AXfrKeyPair::default();
-        let blinding_factors = vec![CanaanScalar::default(); 3];
+        let blinding_factors = vec![SECQ256K1Scalar::default(); 3];
 
         let delegated_cp_proof =
-            DelegatedChaumPedersenProof::<CanaanScalar, CanaanG1, SimFrParamsCanaan> {
+            DelegatedChaumPedersenProof::<SECQ256K1Scalar, SECQ256K1G1, SimFrParamsSecq256k1> {
                 inspection_comm: Default::default(),
-                randomizers: vec![CanaanG1::default(); 3],
-                response_scalars: vec![(CanaanScalar::default(), CanaanScalar::default()); 3],
+                randomizers: vec![SECQ256K1G1::default(); 3],
+                response_scalars: vec![(SECQ256K1Scalar::default(), SECQ256K1Scalar::default()); 3],
                 params_phantom: Default::default(),
             };
 
         let delegated_cp_inspection = DelegatedChaumPedersenInspection::<
-            CanaanScalar,
-            CanaanG1,
-            SimFrParamsCanaan,
+            SECQ256K1Scalar,
+            SECQ256K1G1,
+            SimFrParamsSecq256k1,
         > {
             committed_data_and_randomizer: vec![
-                (CanaanScalar::default(), CanaanScalar::default());
+                (
+                    SECQ256K1Scalar::default(),
+                    SECQ256K1Scalar::default()
+                );
                 3
             ],
             r: BLSScalar::default(),
@@ -75,8 +80,8 @@ impl Default for AXfrAddressFoldingWitness {
             group_phantom: Default::default(),
         };
 
-        let beta = CanaanScalar::default();
-        let lambda = CanaanScalar::default();
+        let beta = SECQ256K1Scalar::default();
+        let lambda = SECQ256K1Scalar::default();
 
         Self {
             keypair,
@@ -97,8 +102,8 @@ pub fn create_address_folding<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
     bp_gens_len: usize,
     keypair: &AXfrKeyPair,
 ) -> Result<(AXfrAddressFoldingInstance, AXfrAddressFoldingWitness)> {
-    let pc_gens = PedersenCommitmentCanaan::default();
-    let bp_gens = ark_bulletproofs_canaan::BulletproofGens::new(bp_gens_len, 1);
+    let pc_gens = PedersenCommitmentSecq256k1::default();
+    let bp_gens = ark_bulletproofs_secq256k1::BulletproofGens::new(bp_gens_len, 1);
 
     let public_key = keypair.get_public_key();
     let secret_key = keypair.get_secret_key();
@@ -110,7 +115,7 @@ pub fn create_address_folding<R: CryptoRng + RngCore, D: Digest<OutputSize = U64
         { ScalarMulProof::prove(prng, &bp_gens, transcript, &public_key.0, &secret_key.0)? };
 
     let (delegated_cp_proof, delegated_cp_inspection, beta, lambda) = {
-        let secret_key_in_fq = CanaanScalar::from_bytes(&secret_key.0.to_bytes())?;
+        let secret_key_in_fq = SECQ256K1Scalar::from_bytes(&secret_key.0.to_bytes())?;
 
         prove_delegated_chaum_pedersen(
             prng,
@@ -150,9 +155,9 @@ pub fn verify_address_folding<D: Digest<OutputSize = U64> + Default>(
     transcript: &mut Transcript,
     bp_gens_len: usize,
     instance: &AXfrAddressFoldingInstance,
-) -> Result<(CanaanScalar, CanaanScalar)> {
-    let pc_gens = PedersenCommitmentCanaan::default();
-    let bp_gens = ark_bulletproofs_canaan::BulletproofGens::new(bp_gens_len, 1);
+) -> Result<(SECQ256K1Scalar, SECQ256K1Scalar)> {
+    let pc_gens = PedersenCommitmentSecq256k1::default();
+    let bp_gens = ark_bulletproofs_secq256k1::BulletproofGens::new(bp_gens_len, 1);
 
     // important: address folding relies significantly on the Fiat-Shamir transform.
     transcript.append_message(b"hash", hash.finalize().as_slice());
@@ -331,14 +336,14 @@ pub fn prove_address_folding_in_cs(
 
     // 3. allocate the simulated field elements and obtain their bit representations.
     let x_sim_fr =
-        SimFr::<SimFrParamsCanaan>::from(&witness.keypair.get_public_key().0.get_x().into());
+        SimFr::<SimFrParamsSecq256k1>::from(&witness.keypair.get_public_key().0.get_x().into());
     let (x_sim_fr_var, x_sim_bits_vars) = SimFrVar::alloc_witness(cs, &x_sim_fr);
     let y_sim_fr =
-        SimFr::<SimFrParamsCanaan>::from(&witness.keypair.get_public_key().0.get_y().into());
+        SimFr::<SimFrParamsSecq256k1>::from(&witness.keypair.get_public_key().0.get_y().into());
     let (y_sim_fr_var, y_sim_bits_vars) = SimFrVar::alloc_witness(cs, &y_sim_fr);
 
     // we can do so only because the secp256k1's order is smaller than its base field modulus.
-    let s_sim_fr = SimFr::<SimFrParamsCanaan>::from(&witness.keypair.get_secret_key().0.into());
+    let s_sim_fr = SimFr::<SimFrParamsSecq256k1>::from(&witness.keypair.get_secret_key().0.into());
     let (s_sim_fr_var, s_sim_bits_vars) = SimFrVar::alloc_witness(cs, &s_sim_fr);
 
     // 4. check that the bit representations are the same as the one provided through scalars.
@@ -362,31 +367,32 @@ pub fn prove_address_folding_in_cs(
     // 5. allocate the simulated field elements for the delegated Chaum-Pedersen protocol.
     // note: the verifier will combine the challenges using the power series of lambda.
     let lambda_series = vec![
-        CanaanScalar::one(),
+        SECQ256K1Scalar::one(),
         witness.lambda,
         witness.lambda * witness.lambda,
     ];
     let beta_lambda_series = lambda_series
         .iter()
         .map(|v| *v * witness.beta)
-        .collect::<Vec<CanaanScalar>>();
+        .collect::<Vec<SECQ256K1Scalar>>();
 
     // skip the first one
     let mut lambda_series_vars_skip_first = vec![];
     for lambda_series_val in lambda_series.iter().skip(1) {
-        let sim_fr = SimFr::<SimFrParamsCanaan>::from(&<CanaanScalar as Into<BigUint>>::into(
-            *lambda_series_val,
-        ));
-        lambda_series_vars_skip_first.push(SimFrVar::<SimFrParamsCanaan>::alloc_input(cs, &sim_fr));
+        let sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+            &<SECQ256K1Scalar as Into<BigUint>>::into(*lambda_series_val),
+        );
+        lambda_series_vars_skip_first
+            .push(SimFrVar::<SimFrParamsSecq256k1>::alloc_input(cs, &sim_fr));
     }
 
     // include the first one
     let mut beta_lambda_series_vars = vec![];
     for beta_lambda_series_var in beta_lambda_series.iter() {
-        let sim_fr = SimFr::<SimFrParamsCanaan>::from(&<CanaanScalar as Into<BigUint>>::into(
-            *beta_lambda_series_var,
-        ));
-        beta_lambda_series_vars.push(SimFrVar::<SimFrParamsCanaan>::alloc_input(cs, &sim_fr));
+        let sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+            &<SECQ256K1Scalar as Into<BigUint>>::into(*beta_lambda_series_var),
+        );
+        beta_lambda_series_vars.push(SimFrVar::<SimFrParamsSecq256k1>::alloc_input(cs, &sim_fr));
     }
 
     let query_vars = [x_sim_fr_var, y_sim_fr_var, s_sim_fr_var]
@@ -398,24 +404,27 @@ pub fn prove_address_folding_in_cs(
                 .iter(),
         )
         .map(|(v_var, (_, blinding_factor))| {
-            let sim_fr = SimFr::<SimFrParamsCanaan>::from(&<CanaanScalar as Into<BigUint>>::into(
-                *blinding_factor,
-            ));
+            let sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+                &<SECQ256K1Scalar as Into<BigUint>>::into(*blinding_factor),
+            );
             let (blinding_factor_var, _) =
-                SimFrVar::<SimFrParamsCanaan>::alloc_witness(cs, &sim_fr);
+                SimFrVar::<SimFrParamsSecq256k1>::alloc_witness(cs, &sim_fr);
 
             (v_var.clone(), blinding_factor_var)
         })
-        .collect::<Vec<(SimFrVar<SimFrParamsCanaan>, SimFrVar<SimFrParamsCanaan>)>>();
+        .collect::<Vec<(
+            SimFrVar<SimFrParamsSecq256k1>,
+            SimFrVar<SimFrParamsSecq256k1>,
+        )>>();
 
     let combined_response_scalar = witness.delegated_cp_proof.response_scalars[0].0
         + witness.delegated_cp_proof.response_scalars[1].0 * witness.lambda
         + witness.delegated_cp_proof.response_scalars[2].0 * witness.lambda * witness.lambda;
-    let combined_response_scalar_sim_fr = SimFr::<SimFrParamsCanaan>::from(
-        &<CanaanScalar as Into<BigUint>>::into(combined_response_scalar),
+    let combined_response_scalar_sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+        &<SECQ256K1Scalar as Into<BigUint>>::into(combined_response_scalar),
     );
     let combined_response_scalar_var =
-        SimFrVar::<SimFrParamsCanaan>::alloc_input(cs, &combined_response_scalar_sim_fr);
+        SimFrVar::<SimFrParamsSecq256k1>::alloc_input(cs, &combined_response_scalar_sim_fr);
 
     let mut lhs = query_vars[0].0.mul(cs, &beta_lambda_series_vars[0]);
 
@@ -442,9 +451,10 @@ pub fn prove_address_folding_in_cs(
     res.enforce_zero(cs);
 
     // 6. merge limbs of the committed data as well as the randomizer scalars.
-    let mut all_limbs = Vec::with_capacity(2 * query_vars.len() * SimFrParamsCanaan::NUM_OF_LIMBS);
+    let mut all_limbs =
+        Vec::with_capacity(2 * query_vars.len() * SimFrParamsSecq256k1::NUM_OF_LIMBS);
     let mut all_limbs_var =
-        Vec::with_capacity(2 * query_vars.len() * SimFrParamsCanaan::NUM_OF_LIMBS);
+        Vec::with_capacity(2 * query_vars.len() * SimFrParamsSecq256k1::NUM_OF_LIMBS);
 
     // append all the data
     for (v, _) in query_vars.iter() {
@@ -461,10 +471,10 @@ pub fn prove_address_folding_in_cs(
     let mut compressed_limbs = Vec::new();
     let mut compressed_limbs_var = Vec::new();
 
-    let num_limbs_compressed = BLSScalar::capacity() / SimFrParamsCanaan::BIT_PER_LIMB;
+    let num_limbs_compressed = BLSScalar::capacity() / SimFrParamsSecq256k1::BIT_PER_LIMB;
 
     let step_vec = (1..=num_limbs_compressed)
-        .map(|i| BLSScalar::from(&BigUint::one().shl(SimFrParamsCanaan::BIT_PER_LIMB * i)))
+        .map(|i| BLSScalar::from(&BigUint::one().shl(SimFrParamsSecq256k1::BIT_PER_LIMB * i)))
         .collect::<Vec<BLSScalar>>();
 
     for (limbs, limbs_var) in all_limbs
@@ -474,7 +484,8 @@ pub fn prove_address_folding_in_cs(
         let mut sum = BigUint::zero();
         for (i, limb) in limbs.iter().enumerate() {
             sum.add_assign(
-                <BLSScalar as Into<BigUint>>::into(*limb).shl(SimFrParamsCanaan::BIT_PER_LIMB * i),
+                <BLSScalar as Into<BigUint>>::into(*limb)
+                    .shl(SimFrParamsSecq256k1::BIT_PER_LIMB * i),
             );
         }
         compressed_limbs.push(BLSScalar::from(&sum));
@@ -546,18 +557,18 @@ pub fn prove_address_folding_in_cs(
     cs.prepare_pi_variable(comm_var);
 
     for fr_var in lambda_series_vars_skip_first.iter() {
-        for i in 0..SimFrParamsCanaan::NUM_OF_LIMBS {
+        for i in 0..SimFrParamsSecq256k1::NUM_OF_LIMBS {
             cs.prepare_pi_variable(fr_var.var[i]);
         }
     }
 
     for fr_var in beta_lambda_series_vars.iter() {
-        for i in 0..SimFrParamsCanaan::NUM_OF_LIMBS {
+        for i in 0..SimFrParamsSecq256k1::NUM_OF_LIMBS {
             cs.prepare_pi_variable(fr_var.var[i]);
         }
     }
 
-    for i in 0..SimFrParamsCanaan::NUM_OF_LIMBS {
+    for i in 0..SimFrParamsSecq256k1::NUM_OF_LIMBS {
         cs.prepare_pi_variable(combined_response_scalar_var.var[i]);
     }
 
@@ -567,36 +578,36 @@ pub fn prove_address_folding_in_cs(
 /// Convert the instance into input to the Plonk verifier.
 pub fn prepare_verifier_input(
     instance: &AXfrAddressFoldingInstance,
-    beta: &CanaanScalar,
-    lambda: &CanaanScalar,
+    beta: &SECQ256K1Scalar,
+    lambda: &SECQ256K1Scalar,
 ) -> Vec<BLSScalar> {
     let mut v = vec![instance.delegated_cp_proof.inspection_comm];
 
-    let lambda_series = vec![CanaanScalar::one(), *lambda, *lambda * lambda];
+    let lambda_series = vec![SECQ256K1Scalar::one(), *lambda, *lambda * lambda];
     let beta_lambda_series = lambda_series
         .iter()
         .map(|v| *v * beta)
-        .collect::<Vec<CanaanScalar>>();
+        .collect::<Vec<SECQ256K1Scalar>>();
 
     for lambda_series_val in lambda_series.iter().skip(1) {
-        let sim_fr = SimFr::<SimFrParamsCanaan>::from(&<CanaanScalar as Into<BigUint>>::into(
-            *lambda_series_val,
-        ));
+        let sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+            &<SECQ256K1Scalar as Into<BigUint>>::into(*lambda_series_val),
+        );
         v.extend_from_slice(&sim_fr.limbs);
     }
 
     for beta_lambda_series_val in beta_lambda_series.iter() {
-        let sim_fr = SimFr::<SimFrParamsCanaan>::from(&<CanaanScalar as Into<BigUint>>::into(
-            *beta_lambda_series_val,
-        ));
+        let sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+            &<SECQ256K1Scalar as Into<BigUint>>::into(*beta_lambda_series_val),
+        );
         v.extend_from_slice(&sim_fr.limbs);
     }
 
     let combined_response_scalar = instance.delegated_cp_proof.response_scalars[0].0
         + instance.delegated_cp_proof.response_scalars[1].0 * lambda
         + instance.delegated_cp_proof.response_scalars[2].0 * lambda * lambda;
-    let combined_response_scalar_sim_fr = SimFr::<SimFrParamsCanaan>::from(
-        &<CanaanScalar as Into<BigUint>>::into(combined_response_scalar),
+    let combined_response_scalar_sim_fr = SimFr::<SimFrParamsSecq256k1>::from(
+        &<SECQ256K1Scalar as Into<BigUint>>::into(combined_response_scalar),
     );
     v.extend_from_slice(&combined_response_scalar_sim_fr.limbs);
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -64,8 +64,8 @@ version = '^0.3.0'
 default-features = false
 features = ['asm']
 
-[dependencies.ark-bulletproofs-canaan]
-git = "https://github.com/FindoraNetwork/ark-bulletproofs-canaan"
+[dependencies.ark-bulletproofs-secq256k1]
+git = "https://github.com/FindoraNetwork/ark-bulletproofs-secq256k1"
 default-features = false
 features = ["yoloproofs"]
 
@@ -81,7 +81,7 @@ default = [
     'std',
     'u64_backend',
 ]
-std = ['curve25519-dalek/std', 'ark-bulletproofs-canaan/std']
+std = ['curve25519-dalek/std', 'ark-bulletproofs-secq256k1/std']
 alloc = ['curve25519-dalek/alloc']
 nightly = [
     'curve25519-dalek/nightly',

--- a/crypto/src/basic/pedersen_comm.rs
+++ b/crypto/src/basic/pedersen_comm.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::traits::MultiscalarMul;
-use zei_algebra::canaan::{CanaanG1, CanaanScalar};
 use zei_algebra::ops::{Add, Mul};
 use zei_algebra::ristretto::{RistrettoPoint, RistrettoScalar};
+use zei_algebra::secq256k1::{SECQ256K1Scalar, SECQ256K1G1};
 use zei_algebra::traits::Group;
 
 /// Trait for Pedersen commitment.
@@ -63,41 +63,41 @@ impl From<&PedersenCommitmentRistretto> for bulletproofs::PedersenGens {
 
 #[allow(non_snake_case)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-/// The Pedersen commitment implementation for the Canaan group.
-pub struct PedersenCommitmentCanaan {
+/// The Pedersen commitment implementation for the secq256k1 group.
+pub struct PedersenCommitmentSecq256k1 {
     /// The generator for the value part.
-    pub B: CanaanG1,
+    pub B: SECQ256K1G1,
     /// The generator for the blinding part.
-    pub B_blinding: CanaanG1,
+    pub B_blinding: SECQ256K1G1,
 }
 
-impl Default for PedersenCommitmentCanaan {
+impl Default for PedersenCommitmentSecq256k1 {
     fn default() -> Self {
-        let pc_gens = ark_bulletproofs_canaan::PedersenGens::default();
+        let pc_gens = ark_bulletproofs_secq256k1::PedersenGens::default();
         Self {
-            B: CanaanG1::from_raw(pc_gens.B),
-            B_blinding: CanaanG1::from_raw(pc_gens.B_blinding),
+            B: SECQ256K1G1::from_raw(pc_gens.B),
+            B_blinding: SECQ256K1G1::from_raw(pc_gens.B_blinding),
         }
     }
 }
 
-impl PedersenCommitment<CanaanG1> for PedersenCommitmentCanaan {
-    fn generator(&self) -> CanaanG1 {
+impl PedersenCommitment<SECQ256K1G1> for PedersenCommitmentSecq256k1 {
+    fn generator(&self) -> SECQ256K1G1 {
         self.B
     }
 
-    fn blinding_generator(&self) -> CanaanG1 {
+    fn blinding_generator(&self) -> SECQ256K1G1 {
         self.B_blinding
     }
 
-    fn commit(&self, value: CanaanScalar, blinding: CanaanScalar) -> CanaanG1 {
+    fn commit(&self, value: SECQ256K1Scalar, blinding: SECQ256K1Scalar) -> SECQ256K1G1 {
         self.B.mul(&value).add(&self.B_blinding.mul(&blinding))
     }
 }
 
-impl From<&PedersenCommitmentCanaan> for ark_bulletproofs_canaan::PedersenGens {
-    fn from(rp: &PedersenCommitmentCanaan) -> Self {
-        ark_bulletproofs_canaan::PedersenGens {
+impl From<&PedersenCommitmentSecq256k1> for ark_bulletproofs_secq256k1::PedersenGens {
+    fn from(rp: &PedersenCommitmentSecq256k1) -> Self {
+        ark_bulletproofs_secq256k1::PedersenGens {
             B: rp.B.get_raw(),
             B_blinding: rp.B_blinding.get_raw(),
         }

--- a/crypto/src/field_simulation.rs
+++ b/crypto/src/field_simulation.rs
@@ -83,11 +83,11 @@ impl SimFrParams for SimFrParamsRistretto {
     }
 }
 
-/// The parameters for field simulation for the Canaan scalar field.
+/// The parameters for field simulation for the secq256k1 scalar field.
 #[derive(Clone, Default, Eq, PartialEq, Debug)]
-pub struct SimFrParamsCanaan;
+pub struct SimFrParamsSecq256k1;
 
-impl SimFrParams for SimFrParamsCanaan {
+impl SimFrParams for SimFrParamsSecq256k1 {
     const NUM_OF_LIMBS: usize = 6;
     const BIT_PER_LIMB: usize = 44;
     const BIT_IN_TOP_LIMB: usize = 36;
@@ -604,19 +604,19 @@ mod test_ristretto {
 }
 
 #[cfg(test)]
-mod test_canaan {
-    use crate::field_simulation::{SimFr, SimFrParams, SimFrParamsCanaan};
+mod test_secq256k1 {
+    use crate::field_simulation::{SimFr, SimFrParams, SimFrParamsSecq256k1};
     use num_bigint::{BigUint, RandBigInt};
     use num_integer::Integer;
     use rand_chacha::ChaCha20Rng;
     use zei_algebra::prelude::*;
 
-    type SimFrTest = SimFr<SimFrParamsCanaan>;
+    type SimFrTest = SimFr<SimFrParamsSecq256k1>;
 
     #[test]
     fn test_sim_fr_biguint_conversion() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);
@@ -630,7 +630,7 @@ mod test_canaan {
     #[test]
     fn test_sub() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);
@@ -651,7 +651,7 @@ mod test_canaan {
     #[test]
     fn test_mul() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);
@@ -680,7 +680,7 @@ mod test_canaan {
     #[test]
     fn test_enforce_zero() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..1000 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);
@@ -707,7 +707,7 @@ mod test_canaan {
     #[should_panic]
     fn test_enforce_zero_panic() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         let a = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);
         let b = rng.gen_biguint_range(&BigUint::zero(), &r_biguint);

--- a/plonk/src/plonk/constraint_system/field_simulation/fr_mul_var.rs
+++ b/plonk/src/plonk/constraint_system/field_simulation/fr_mul_var.rs
@@ -389,15 +389,15 @@ mod test_ristretto {
 }
 
 #[cfg(test)]
-mod test_canaan {
+mod test_secq256k1 {
     use crate::plonk::constraint_system::{field_simulation::SimFrVar, turbo::TurboCS};
     use num_bigint::{BigUint, RandBigInt};
     use rand_chacha::ChaCha20Rng;
     use zei_algebra::{bls12_381::BLSScalar, prelude::*};
-    use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsCanaan};
+    use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsSecq256k1};
 
-    type SimFrTest = SimFr<SimFrParamsCanaan>;
-    type SimFrVarTest = SimFrVar<SimFrParamsCanaan>;
+    type SimFrTest = SimFr<SimFrParamsSecq256k1>;
+    type SimFrVarTest = SimFrVar<SimFrParamsSecq256k1>;
 
     #[test]
     fn test_enforce_zero_trivial() {
@@ -413,7 +413,7 @@ mod test_canaan {
     #[test]
     fn test_enforce_zero() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..1000 {
             let mut cs = TurboCS::<BLSScalar>::new();
@@ -443,7 +443,7 @@ mod test_canaan {
     #[should_panic]
     fn test_enforce_zero_panic() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let r_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let r_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         let mut cs = TurboCS::<BLSScalar>::new();
 

--- a/plonk/src/plonk/constraint_system/field_simulation/fr_var.rs
+++ b/plonk/src/plonk/constraint_system/field_simulation/fr_var.rs
@@ -336,7 +336,7 @@ mod test_ristretto {
 }
 
 #[cfg(test)]
-mod test_canaan {
+mod test_secq256k1 {
     use crate::plonk::constraint_system::{
         field_simulation::{SimFrMulVar, SimFrVar},
         TurboCS,
@@ -344,15 +344,15 @@ mod test_canaan {
     use num_bigint::{BigUint, RandBigInt};
     use rand_chacha::ChaCha20Rng;
     use zei_algebra::{bls12_381::BLSScalar, ops::Shl, prelude::*};
-    use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsCanaan};
+    use zei_crypto::field_simulation::{SimFr, SimFrParams, SimFrParamsSecq256k1};
 
-    type SimFrTest = SimFr<SimFrParamsCanaan>;
-    type SimFrVarTest = SimFrVar<SimFrParamsCanaan>;
-    type SimFrMulVarTest = SimFrMulVar<SimFrParamsCanaan>;
+    type SimFrTest = SimFr<SimFrParamsSecq256k1>;
+    type SimFrVarTest = SimFrVar<SimFrParamsSecq256k1>;
+    type SimFrMulVarTest = SimFrMulVar<SimFrParamsSecq256k1>;
 
     fn test_sim_fr_equality(cs: TurboCS<BLSScalar>, val: &SimFrVarTest) {
         let mut cs = cs;
-        for i in 0..SimFrParamsCanaan::NUM_OF_LIMBS {
+        for i in 0..SimFrParamsSecq256k1::NUM_OF_LIMBS {
             cs.insert_constant_gate(val.var[i], val.val.limbs[i]);
         }
 
@@ -362,7 +362,7 @@ mod test_canaan {
 
     fn test_sim_fr_mul_equality(cs: TurboCS<BLSScalar>, val: &SimFrMulVarTest) {
         let mut cs = cs;
-        for i in 0..SimFrParamsCanaan::NUM_OF_LIMBS_MUL {
+        for i in 0..SimFrParamsSecq256k1::NUM_OF_LIMBS_MUL {
             cs.insert_constant_gate(val.var[i], val.val.limbs[i]);
         }
 
@@ -373,7 +373,7 @@ mod test_canaan {
     #[test]
     fn test_alloc_constant() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let p_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let p_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &p_biguint);
@@ -390,7 +390,7 @@ mod test_canaan {
     #[test]
     fn test_alloc_witness() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let p_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let p_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &p_biguint);
@@ -407,7 +407,7 @@ mod test_canaan {
     #[test]
     fn test_sub() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let p_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let p_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &p_biguint);
@@ -431,7 +431,7 @@ mod test_canaan {
     #[test]
     fn test_mul() {
         let mut rng = ChaCha20Rng::from_entropy();
-        let p_biguint = SimFrParamsCanaan::scalar_field_in_biguint();
+        let p_biguint = SimFrParamsSecq256k1::scalar_field_in_biguint();
 
         for _ in 0..100 {
             let a = rng.gen_biguint_range(&BigUint::zero(), &p_biguint);


### PR DESCRIPTION
* **The major changes of this PR**

Many people have tried to find a curve over secp256k1, and eventually found that other people have done the same thing, and reached the likely optimal conclusion---secq256k1, which swaps the r and q of secp256k1.

Compared with Canaan curve, secq256k1 is smaller, but secq256k1 has a = 0 which means some elligator doesn't work. However, since we don't use any elligator, it makes more sense to switch to a smaller curve with more concise parameters.

cite: https://twitter.com/benediktbuenz/status/993568753181802496

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

