### PR TITLE
Remove a line of debug code

### DIFF
--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -153,8 +153,6 @@ impl ProverParams {
             ),
         };
 
-        println!("{} {} {}", n_payers, n_payees, cs.size());
-
         let pcs = KZGCommitmentSchemeBLS::from_unchecked_bytes(&srs)
             .c(d!(ZeiError::DeserializationError))?;
 


### PR DESCRIPTION
* **The major changes of this PR**

This PR removes a `println` that outputs something during the execution but is not needed. 

This is to keep the program's output clean.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

