### PR TITLE
Use arkworks-rs serialization to reduce proof size

### DIFF
--- a/algebra/src/serialization.rs
+++ b/algebra/src/serialization.rs
@@ -6,6 +6,8 @@ use crate::{
     ristretto::{CompressedEdwardsY, CompressedRistretto, RistrettoPoint, RistrettoScalar},
     secq256k1::SECQ256K1Scalar,
 };
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::io::Cursor;
 use bulletproofs::RangeProof;
 use serde::Serializer;
 
@@ -122,10 +124,12 @@ impl ZeiFromToBytes for bulletproofs::r1cs::R1CSProof {
 
 impl ZeiFromToBytes for ark_bulletproofs_secq256k1::r1cs::R1CSProof {
     fn zei_to_bytes(&self) -> Vec<u8> {
-        self.to_bytes().unwrap()
+        let mut cursor = Cursor::new(Vec::new());
+        self.serialize(&mut cursor).unwrap();
+        cursor.into_inner()
     }
     fn zei_from_bytes(bytes: &[u8]) -> Result<ark_bulletproofs_secq256k1::r1cs::R1CSProof> {
-        ark_bulletproofs_secq256k1::r1cs::R1CSProof::from_bytes(bytes)
+        ark_bulletproofs_secq256k1::r1cs::R1CSProof::deserialize(bytes)
             .map_err(|_| eg!(ZeiError::DeserializationError))
     }
 }


### PR DESCRIPTION
* **The major changes of this PR**

During the transition from the previous framework to the new one, we used `arkworks-rs`'s `to_bytes` and `from_bytes` for serialization, which has two limitations: (1) this interface will disappear in newer versions of `arkworks-rs` and (2) `to_bytes` and `from_bytes` don't compress the data.

This PR is for the Zei library to adopt the upstream changes. A new release needs to be cut.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

