### PR TITLE
Rename delegated Chaum-Pedersen to delegated Schnorr

### DIFF
--- a/api/src/setup.rs
+++ b/api/src/setup.rs
@@ -25,9 +25,7 @@ use zei_algebra::{
     prelude::*,
     ristretto::RistrettoScalar,
 };
-use zei_crypto::delegated_chaum_pedersen::{
-    DelegatedChaumPedersenInspection, DelegatedChaumPedersenProof,
-};
+use zei_crypto::delegated_schnorr::{DelegatedSchnorrInspection, DelegatedSchnorrProof};
 use zei_crypto::field_simulation::SimFrParamsRistretto;
 use zei_plonk::{
     plonk::{
@@ -173,30 +171,26 @@ impl ProverParams {
         let srs = SRS.c(d!(ZeiError::MissingSRSError))?;
         let zero = BLSScalar::zero();
 
-        let proof =
-            DelegatedChaumPedersenProof::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
-                inspection_comm: Default::default(),
-                randomizers: vec![RistrettoPoint::default(); 3],
-                response_scalars: vec![(RistrettoScalar::default(), RistrettoScalar::default()); 3],
-                params_phantom: Default::default(),
-            };
-
-        let non_zk_state = DelegatedChaumPedersenInspection::<
-            RistrettoScalar,
-            RistrettoPoint,
-            SimFrParamsRistretto,
-        > {
-            committed_data_and_randomizer: vec![
-                (
-                    RistrettoScalar::default(),
-                    RistrettoScalar::default()
-                );
-                3
-            ],
-            r: BLSScalar::default(),
+        let proof = DelegatedSchnorrProof::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
+            inspection_comm: Default::default(),
+            randomizers: vec![RistrettoPoint::default(); 3],
+            response_scalars: vec![(RistrettoScalar::default(), RistrettoScalar::default()); 3],
             params_phantom: Default::default(),
-            group_phantom: Default::default(),
         };
+
+        let non_zk_state =
+            DelegatedSchnorrInspection::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
+                committed_data_and_randomizer: vec![
+                    (
+                        RistrettoScalar::default(),
+                        RistrettoScalar::default()
+                    );
+                    3
+                ],
+                r: BLSScalar::default(),
+                params_phantom: Default::default(),
+                group_phantom: Default::default(),
+            };
 
         let beta = RistrettoScalar::zero();
         let lambda = RistrettoScalar::zero();
@@ -234,30 +228,26 @@ impl ProverParams {
     pub fn abar_to_bar_params(tree_depth: usize) -> Result<ProverParams> {
         let bls_zero = BLSScalar::zero();
 
-        let proof =
-            DelegatedChaumPedersenProof::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
-                inspection_comm: Default::default(),
-                randomizers: vec![RistrettoPoint::default(); 3],
-                response_scalars: vec![(RistrettoScalar::default(), RistrettoScalar::default()); 3],
-                params_phantom: Default::default(),
-            };
-
-        let non_zk_state = DelegatedChaumPedersenInspection::<
-            RistrettoScalar,
-            RistrettoPoint,
-            SimFrParamsRistretto,
-        > {
-            committed_data_and_randomizer: vec![
-                (
-                    RistrettoScalar::default(),
-                    RistrettoScalar::default()
-                );
-                3
-            ],
-            r: BLSScalar::default(),
+        let proof = DelegatedSchnorrProof::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
+            inspection_comm: Default::default(),
+            randomizers: vec![RistrettoPoint::default(); 3],
+            response_scalars: vec![(RistrettoScalar::default(), RistrettoScalar::default()); 3],
             params_phantom: Default::default(),
-            group_phantom: Default::default(),
         };
+
+        let non_zk_state =
+            DelegatedSchnorrInspection::<RistrettoScalar, RistrettoPoint, SimFrParamsRistretto> {
+                committed_data_and_randomizer: vec![
+                    (
+                        RistrettoScalar::default(),
+                        RistrettoScalar::default()
+                    );
+                    3
+                ],
+                r: BLSScalar::default(),
+                params_phantom: Default::default(),
+                group_phantom: Default::default(),
+            };
 
         let beta = RistrettoScalar::zero();
         let lambda = RistrettoScalar::zero();

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -29,7 +29,7 @@ pub mod basic;
 pub mod bulletproofs;
 /// The module for confidential anonymous credentials.
 pub mod confidential_anon_creds;
-/// The module for the delegated Chaum-Pedersen protocol.
-pub mod delegated_chaum_pedersen;
+/// The module for the delegated Schnorr protocol.
+pub mod delegated_schnorr;
 /// The module for field simulation.
 pub mod field_simulation;


### PR DESCRIPTION
* **The major changes of this PR**

A more careful reading of the history suggests that Schnorr may be the original person who provides the "one-commitment" case, i.e., proof of knowledge. Before this is shipped to the mainnet, it is ideal that we make this change.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [x] Impact mainnet data compatibility?

* **Extra documentations**

