### PR TITLE
Addition checks for blind asset records

### DIFF
--- a/zei_api/src/xfr/asset_record.rs
+++ b/zei_api/src/xfr/asset_record.rs
@@ -406,7 +406,7 @@ fn sample_blind_asset_record<R: CryptoRng + RngCore>(
                         &pc_gens,
                         asset_record.amount,
                         &amount_blinds.0,
-                        amount_blinds.1,
+                        &amount_blinds.1,
                     ),
                     XfrAssetType::from_blind(
                         &pc_gens,

--- a/zei_api/src/xfr/asset_record.rs
+++ b/zei_api/src/xfr/asset_record.rs
@@ -529,6 +529,19 @@ pub fn open_blind_asset_record(
             let owner_memo = owner_memo.as_ref().c(d!(ZeiError::ParameterError))?;
             let amount = owner_memo.decrypt_amount(&keypair).c(d!())?;
             let amount_blinds = owner_memo.derive_amount_blinds(&keypair).c(d!())?;
+
+            let pc_gens = RistrettoPedersenGens::default();
+            if input.amount
+                != XfrAmount::from_blinds(
+                    &pc_gens,
+                    amount,
+                    &amount_blinds.0,
+                    amount_blinds.1,
+                )
+            {
+                return Err(eg!(ZeiError::ParameterError));
+            }
+
             (
                 amount,
                 input
@@ -545,6 +558,14 @@ pub fn open_blind_asset_record(
             let asset_type = owner_memo.decrypt_asset_type(&keypair).c(d!())?;
             let asset_type_blind =
                 owner_memo.derive_asset_type_blind(&keypair).c(d!())?;
+
+            let pc_gens = RistrettoPedersenGens::default();
+            if input.asset_type
+                != XfrAssetType::from_blind(&pc_gens, &asset_type, &asset_type_blind)
+            {
+                return Err(eg!(ZeiError::ParameterError));
+            }
+
             (
                 input.amount.get_amount().c(d!(ZeiError::ParameterError))?,
                 asset_type,
@@ -561,10 +582,27 @@ pub fn open_blind_asset_record(
             let asset_type_blind =
                 owner_memo.derive_asset_type_blind(&keypair).c(d!())?;
 
+            let pc_gens = RistrettoPedersenGens::default();
+            if input.amount
+                != XfrAmount::from_blinds(
+                    &pc_gens,
+                    amount,
+                    &amount_blinds.0,
+                    amount_blinds.1,
+                )
+            {
+                return Err(eg!(ZeiError::ParameterError));
+            }
+            if input.asset_type
+                != XfrAssetType::from_blind(&pc_gens, &asset_type, &asset_type_blind)
+            {
+                return Err(eg!(ZeiError::ParameterError));
+            }
+
             (amount, asset_type, amount_blinds, asset_type_blind)
         }
     };
-    // TODO check correctness of BlindAssetRecord
+
     Ok(OpenAssetRecord {
         blind_asset_record: input.clone(),
         amount,

--- a/zei_api/src/xfr/asset_record.rs
+++ b/zei_api/src/xfr/asset_record.rs
@@ -536,7 +536,7 @@ pub fn open_blind_asset_record(
                     &pc_gens,
                     amount,
                     &amount_blinds.0,
-                    amount_blinds.1,
+                    &amount_blinds.1,
                 )
             {
                 return Err(eg!(ZeiError::ParameterError));
@@ -588,7 +588,7 @@ pub fn open_blind_asset_record(
                     &pc_gens,
                     amount,
                     &amount_blinds.0,
-                    amount_blinds.1,
+                    &amount_blinds.1,
                 )
             {
                 return Err(eg!(ZeiError::ParameterError));

--- a/zei_api/src/xfr/asset_record.rs
+++ b/zei_api/src/xfr/asset_record.rs
@@ -406,7 +406,7 @@ fn sample_blind_asset_record<R: CryptoRng + RngCore>(
                         &pc_gens,
                         asset_record.amount,
                         &amount_blinds.0,
-                        &amount_blinds.1,
+                        amount_blinds.1,
                     ),
                     XfrAssetType::from_blind(
                         &pc_gens,

--- a/zei_api/src/xfr/structs.rs
+++ b/zei_api/src/xfr/structs.rs
@@ -14,6 +14,7 @@ use algebra::bls12_381::BLSG1;
 use algebra::groups::{Group, Scalar as ZeiScalar};
 use algebra::ristretto::{
     CompressedEdwardsY, CompressedRistretto, RistrettoPoint, RistrettoScalar as Scalar,
+    RistrettoScalar,
 };
 use bulletproofs::RangeProof;
 use crypto::basics::commitments::ristretto_pedersen::RistrettoPedersenGens;
@@ -211,7 +212,7 @@ impl XfrAmount {
         pc_gens: &RistrettoPedersenGens,
         amount: u64,
         blind_lo: &Scalar,
-        blind_hi: &Scalar,
+        blind_hi: RistrettoScalar,
     ) -> Self {
         let (amount_lo, amount_hi) = utils::u64_to_u32_pair(amount);
         let comm_lo = pc_gens
@@ -414,7 +415,7 @@ impl OwnerMemo {
     /// PRNG should be seeded with good entropy instead of being deterministically seeded
     pub fn from_amount<R: CryptoRng + RngCore>(
         prng: &mut R,
-        amount: u64,
+        mut amount: u64,
         pub_key: &XfrPublicKey,
     ) -> Result<(Self, (Scalar, Scalar))> {
         let (r, blind_share) = Scalar::random_scalar_with_compressed_edwards(prng);

--- a/zei_api/src/xfr/structs.rs
+++ b/zei_api/src/xfr/structs.rs
@@ -14,7 +14,6 @@ use algebra::bls12_381::BLSG1;
 use algebra::groups::{Group, Scalar as ZeiScalar};
 use algebra::ristretto::{
     CompressedEdwardsY, CompressedRistretto, RistrettoPoint, RistrettoScalar as Scalar,
-    RistrettoScalar,
 };
 use bulletproofs::RangeProof;
 use crypto::basics::commitments::ristretto_pedersen::RistrettoPedersenGens;

--- a/zei_api/src/xfr/structs.rs
+++ b/zei_api/src/xfr/structs.rs
@@ -212,7 +212,7 @@ impl XfrAmount {
         pc_gens: &RistrettoPedersenGens,
         amount: u64,
         blind_lo: &Scalar,
-        blind_hi: RistrettoScalar,
+        blind_hi: &Scalar,
     ) -> Self {
         let (amount_lo, amount_hi) = utils::u64_to_u32_pair(amount);
         let comm_lo = pc_gens
@@ -415,7 +415,7 @@ impl OwnerMemo {
     /// PRNG should be seeded with good entropy instead of being deterministically seeded
     pub fn from_amount<R: CryptoRng + RngCore>(
         prng: &mut R,
-        mut amount: u64,
+        amount: u64,
         pub_key: &XfrPublicKey,
     ) -> Result<(Self, (Scalar, Scalar))> {
         let (r, blind_share) = Scalar::random_scalar_with_compressed_edwards(prng);


### PR DESCRIPTION
* **The major changes of this PR**

This PR adds additional checks that require consistency between the blind asset records' commitments and owner memos. 

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

